### PR TITLE
[Multinode] Widen TransferCmd tile_id/offsets to u32/u64

### DIFF
--- a/bench/ag_gemm_bench.py
+++ b/bench/ag_gemm_bench.py
@@ -34,7 +34,7 @@ CHUNK_BYTES = 64 * 1024  # baked from AG_CHUNK_BYTES=65536
 
 DEFAULT_SHAPES = (
     # M=57344 hangs during default-warmup 4-node sweeps on H200x.
-    [8192, 16384, 32768, 49152]
+    [8192, 16384, 32768, 49152, 65536]
     if NUM_NODES == 4 else
     [6144, 12288, 24576, 49152, 73728]
     if NUM_NODES == 3 else
@@ -46,7 +46,7 @@ DEFAULT_SHAPES = (
 # unless we cut the comm-CTA budget). The 64-sms default oversubscribes comm
 # CTAs at medium M where the GEMM wave count is lower.
 SMS_PER_SHAPE = {4096: 8, 6144: 8, 8192: 8, 12288: 8, 16384: 8,
-                 24576: 8, 49152: 8, 57344: 8, 73728: 8}
+                 24576: 8, 49152: 8, 65536: 8, 57344: 8, 73728: 8}
 
 
 def avg_then_max_cuda(samples):

--- a/bench/run_emulated_4x4.sh
+++ b/bench/run_emulated_4x4.sh
@@ -103,7 +103,7 @@ run_one() {
         "GEMM_AR_ARRIVAL_QUEUE=1"
         "GEMM_AR_K_DIV=global_world"
         "MKERNEL_BIND_RETAINED_HANDLE=1"
-        "MKERNEL_EFA_NUM_QPS=4"
+        "MKERNEL_EFA_NUM_QPS=${MKERNEL_EFA_NUM_QPS:-4}"
         "MKERNEL_BENCH_BEST_OF_N=0"
         "TORCH_CUDA_ARCH_LIST=9.0a"
         "NUM_NODES=4"

--- a/include/comm/internode/arrival.cuh
+++ b/include/comm/internode/arrival.cuh
@@ -49,8 +49,9 @@ struct ArrivalFlags {
 
 /**
  * Create arrival flags array.
- * Allocates host-pinned memory with cudaHostAllocMapped, gets device pointer.
- * RDMA registration is done separately (caller passes pd + registers mr).
+ * Allocates device memory with cudaMalloc; the host_ptr field aliases the
+ * same device pointer. RDMA registration is done separately (caller passes
+ * pd + registers mr).
  */
 inline ArrivalFlags create_arrival_flags(int count, int tail_count = 0) {
     ArrivalFlags flags{};
@@ -109,7 +110,8 @@ inline void reset_arrival_flags(ArrivalFlags& flags) {
 }
 
 /**
- * Destroy arrival flags. Deregisters MR if set, frees host-pinned memory.
+ * Destroy arrival flags. Caller must already have deregistered the MR;
+ * this releases device memory (default) or host-pinned memory (mapped flags).
  */
 inline void destroy_arrival_flags(ArrivalFlags& flags) {
     // MR deregistration is caller's responsibility (needs ibv_dereg_mr)

--- a/include/comm/internode/proxy.h
+++ b/include/comm/internode/proxy.h
@@ -712,8 +712,8 @@ private:
         const int dst_virtual = dst_slot + n_peers * (src_bank + 1);
         const uint32_t chunk = n.tile_id % (uint32_t)cfg_.total_chunks;
         const uint32_t base = (uint32_t)((uint64_t)n.local_offset % cfg_.a_half_bytes);
-        cmd.tile_id = (uint16_t)(dst_virtual * cfg_.total_chunks + chunk);
-        cmd.remote_offset = (uint32_t)((uint64_t)dst_virtual * cfg_.a_half_bytes + base);
+        cmd.tile_id = (uint32_t)(dst_virtual * cfg_.total_chunks + chunk);
+        cmd.remote_offset = (uint64_t)((uint64_t)dst_virtual * cfg_.a_half_bytes + base);
         return cmd;
     }
 

--- a/include/comm/internode/session.h
+++ b/include/comm/internode/session.h
@@ -282,7 +282,7 @@ struct Session {
  *   2. Register local GPU buffer for RDMA (so NIC can read for sends)
  *   3. Allocate + register receive buffer on GPU (remote writes land here)
  *   4. Create D2H FIFO (host-pinned triggers, device-memory head)
- *   5. Create arrival flags (host-pinned, RDMA-registered)
+ *   5. Create arrival flags (device memory, RDMA-registered)
  *   6. Create flag staging (host-pinned, RDMA-registered)
  *   7. Fill local ConnectionInfo, exchange with peer over TCP
  *   8. Transition QP: INIT → RTR → RTS

--- a/include/comm/internode/session_efa.h
+++ b/include/comm/internode/session_efa.h
@@ -1176,10 +1176,10 @@ inline void prime_first_launch_transport(Session* s) {
             TransferCmd cmd{};
             cmd.cmd_type = CmdType::WRITE;
             cmd.dst_rank = (uint8_t)(s->rank == 0 ? 1 : 0);
-            cmd.tile_id = (uint16_t)dummy_tile;
+            cmd.tile_id = (uint32_t)dummy_tile;
             cmd.bytes = prime_bytes;
-            cmd.local_offset = (uint32_t)global_qp * prime_bytes;
-            cmd.remote_offset = (uint32_t)global_qp * prime_bytes;
+            cmd.local_offset = (uint64_t)global_qp * prime_bytes;
+            cmd.remote_offset = (uint64_t)global_qp * prime_bytes;
             cmd.lane_id = (uint16_t)global_qp;
             cmd.src_view = 0;
             cmd.reserved0 = 0;

--- a/include/comm/internode/types.h
+++ b/include/comm/internode/types.h
@@ -26,23 +26,34 @@ enum class CmdType : uint8_t {
 };
 
 #pragma pack(push, 1)
+// Fields are laid out so each multi-byte field sits entirely inside a single
+// 8-byte word. The D2H FIFO publish writes 8-byte words and uses a release
+// store on word 0 (cmd_type) to commit; straddling a field across two words
+// can produce torn reads on the host. Keep this property when adding fields.
 struct TransferCmd {
+    // Word 0 [0..8): committed last by release-store; host acquires on cmd_type.
     CmdType  cmd_type;       // WRITE or FENCE
     uint8_t  dst_rank;       // target node rank (0..num_nodes-1)
-    uint16_t tile_id;        // first tile of this transfer (arrival metadata payload base)
-    uint32_t bytes;          // transfer size in bytes
-    uint32_t local_offset;   // byte offset into RDMA-registered local buffer
-    uint32_t remote_offset;  // byte offset into RDMA-registered remote buffer
     uint16_t lane_id;        // logical lane / remote queue for structural routing
+    uint32_t tile_id;        // first tile of this transfer (arrival metadata payload base)
+    // Word 1 [8..16):
+    uint64_t remote_offset;  // byte offset into RDMA-registered remote buffer
+    // Word 2 [16..24):
+    uint64_t local_offset;   // byte offset into RDMA-registered local buffer
+    // Word 3 [24..32): packed small fields.
+    uint32_t bytes;          // transfer size in bytes
     uint8_t  src_view;       // 0 = staging buffer, 1 = C_local direct (DMA-BUF), 2 = C_local strided (multi-SGE gather)
     uint8_t  reserved0;      // optional peer/GPU channel id; zero preserves legacy routing
     uint16_t row_span;       // src_view=2: bytes per row run (dst_cols * sizeof(bf16))
+    // Word 4 [32..40):
     uint16_t row_count;      // src_view=2: number of rows gathered (<= ROW_BLOCK)
+    uint8_t  _pad[6];
+    // Word 5 [40..48):
     uint64_t enqueue_device_ns; // GPU globaltimer timestamp just before fifo.push()
 };
 #pragma pack(pop)
 
-static_assert(sizeof(TransferCmd) == 32, "TransferCmd must be exactly 32 bytes");
+static_assert(sizeof(TransferCmd) == 48, "TransferCmd must be exactly 48 bytes");
 
 #pragma pack(push, 1)
 struct ForwardNotify {

--- a/include/dist/backend_proxy.cuh
+++ b/include/dist/backend_proxy.cuh
@@ -106,10 +106,10 @@ distributed_tensor<GL, LOCAL_SIZE, MULTICAST, NUM_CHANNELS, NUM_NODES, TMA_Types
     internode::TransferCmd cmd{};
     cmd.cmd_type      = internode::CmdType::WRITE;
     cmd.dst_rank      = (uint8_t)dst_node;
-    cmd.tile_id       = (uint16_t)imm;
+    cmd.tile_id = (uint32_t)imm;
     cmd.bytes         = bytes;
-    cmd.local_offset  = (uint32_t)local_off;
-    cmd.remote_offset = (uint32_t)remote_off;
+    cmd.local_offset = (uint64_t)local_off;
+    cmd.remote_offset = (uint64_t)remote_off;
     cmd.lane_id       = (uint16_t)lane_id;
     cmd.src_view      = (uint8_t)ch.mode;
 

--- a/include/operators/ag_gemm/ag_gemm.cuh
+++ b/include/operators/ag_gemm/ag_gemm.cuh
@@ -7,16 +7,17 @@
  * Single kernel launch. Two CTA groups run concurrently:
  *
  *   Intra-comm CTAs [0, num_intra_comm):
- *     IPC multicast gather of A shards within the node.
- *     Also post zero-copy RDMA WRs for this rank's M_local slice at kernel
- *     entry (src_view=1 → DMA-BUF MR aliasing A.data_), so the NIC pipelines
- *     the inter-node send concurrently with intra-gather + compute.
+ *     IPC multicast gather of A shards within the node, then phase-2
+ *     republish of RDMA-received peer shards into A_recv. Zero-copy RDMA WRs
+ *     for this rank's M_local slice (src_view=1 → DMA-BUF MR aliasing A.data_)
+ *     are posted by a separate prologue kernel so the NIC pipelines the
+ *     inter-node send concurrently with intra-gather + compute.
  *     Signals barrier[row_block] when each row block is fully gathered.
  *
  *   Comp CTAs [num_intra_comm, 132):
- *     GEMM on all M rows. Atomically claim tiles:
- *       - Local-half tile: wait on intra-node barrier, TMA load from A_distributed_tensor
- *       - Remote-half tile: wait on arrival_flags, TMA load from A_recv_local_tensor
+ *     GEMM on all M rows. CTAs claim tiles by CTA-stride:
+ *       - Local-half tile: wait on intra-node barrier (plane 0), TMA load from A_local
+ *       - Remote-half tile: wait on intra-node barrier (plane 2), TMA load from A_recv
  *
  * The distributed A buffer is DMA-BUF-registered for RDMA (no staging copy).
  */
@@ -207,10 +208,10 @@ __device__ __forceinline__ int ag1_compute_wr_split(int rb_bytes, int ceiling) {
 // Merge: post both inter rbs' DMA-BUF WRs for a single intra row that this
 // rank owns (intra 256-row unit = 2 inter 128-row rbs).
 //
-// Under AG1_MERGE_WR_SPLIT (ceiling N>1), each inter-rb is split into
-// effective_split sub-WRs sized rb_bytes/split, striped across QPs by
-// (rb*split + sw) key. effective_split computed from rb_bytes — only kicks
-// in at large shapes where sub-WR stays >= 2 MB.
+// When WR_SPLIT_CEILING > 1, each inter-rb is split into effective_split
+// sub-WRs sized rb_bytes/split, striped across QPs by (rb*split + sw) key.
+// effective_split computed from rb_bytes — only kicks in at large shapes
+// where sub-WR stays >= 2 MB.
 __device__ inline void post_merge_wrs_for_intra_row(
     const globals& G, int global_row_idx, int chunks_per_rb) {
     constexpr int WR_SPLIT_CEILING = 1;

--- a/include/operators/ag_gemm/ag_gemm.cuh
+++ b/include/operators/ag_gemm/ag_gemm.cuh
@@ -245,10 +245,10 @@ __device__ inline void post_merge_wrs_for_intra_row(
                 internode::TransferCmd cmd{};
                 cmd.cmd_type = internode::CmdType::WRITE;
                 cmd.dst_rank = (uint8_t)peer_rank;
-                cmd.tile_id = (uint16_t)(sap * G.total_chunks + first_chunk);
+                cmd.tile_id = (uint32_t)(sap * G.total_chunks + first_chunk);
                 cmd.bytes = rb_bytes;
                 cmd.local_offset = base_offset;
-                cmd.remote_offset = (uint32_t)sap * (uint32_t)G.a_half_bytes + base_offset;
+                cmd.remote_offset = (uint64_t)sap * (uint64_t)G.a_half_bytes + base_offset;
                 cmd.src_view = 1;
                 cmd.lane_id = (uint16_t)rb;
                 cmd.reserved0 = (uint8_t)(peer_slot * globals::NUM_DEVICES + G.dev_idx);
@@ -271,10 +271,10 @@ __device__ inline void post_merge_wrs_for_intra_row(
                     internode::TransferCmd cmd{};
                     cmd.cmd_type = internode::CmdType::WRITE;
                     cmd.dst_rank = (uint8_t)peer_rank;
-                    cmd.tile_id = (uint16_t)(sap * G.total_chunks + sub_first_chunk);
+                    cmd.tile_id = (uint32_t)(sap * G.total_chunks + sub_first_chunk);
                     cmd.bytes = sub_bytes;
                     cmd.local_offset = sub_base;
-                    cmd.remote_offset = (uint32_t)sap * (uint32_t)G.a_half_bytes + sub_base;
+                    cmd.remote_offset = (uint64_t)sap * (uint64_t)G.a_half_bytes + sub_base;
                     cmd.src_view = 1;
                     cmd.lane_id = (uint16_t)(rb * split + sw);
                     cmd.reserved0 = (uint8_t)(peer_slot * globals::NUM_DEVICES + G.dev_idx);
@@ -300,10 +300,10 @@ __device__ inline void post_ring_forward_wrs_for_intra_row(
     const int dst_slot = internode::slot_at_peer(origin_rank, next_rank, G.num_nodes);
     const int n_peers = G.num_nodes - 1;
     const int dst_virtual = dst_slot + n_peers * dst_bank;
-    const uint32_t src_slot_base =
-        (uint32_t)source_slot * (uint32_t)G.a_half_bytes;
-    const uint32_t dst_slot_base =
-        (uint32_t)dst_virtual * (uint32_t)G.a_half_bytes;
+    const uint64_t src_slot_base =
+        (uint64_t)source_slot * (uint64_t)G.a_half_bytes;
+    const uint64_t dst_slot_base =
+        (uint64_t)dst_virtual * (uint64_t)G.a_half_bytes;
 #pragma unroll
     for (int sub = 0; sub < 2; ++sub) {
         int rb = 2 * global_row_idx + sub;
@@ -330,7 +330,7 @@ __device__ inline void post_ring_forward_wrs_for_intra_row(
             internode::TransferCmd cmd{};
             cmd.cmd_type = internode::CmdType::WRITE;
             cmd.dst_rank = (uint8_t)next_rank;
-            cmd.tile_id = (uint16_t)(dst_virtual * G.total_chunks + sub_first_chunk);
+            cmd.tile_id = (uint32_t)(dst_virtual * G.total_chunks + sub_first_chunk);
             cmd.bytes = sub_bytes;
             cmd.local_offset = src_slot_base + sub_base;
             cmd.remote_offset = dst_slot_base + sub_base;

--- a/include/operators/gemm_ar/gemm_ar.cuh
+++ b/include/operators/gemm_ar/gemm_ar.cuh
@@ -1040,7 +1040,7 @@ struct gemm_ar_scratch_layout {
     int local_done_flag_offset;
     int remote_arrived_flag_offset;
     int remote_arrived_peer_mask_offset;
-    // GEMM_AR_STAGGER_INTRA: per-primary-CTA started signal (max 4 entries).
+    // GEMM_AR_STAGGER_INTRA: per-primary-CTA started signal (max 16 entries).
     // Primary intra CTAs (offset < num_intra_ar_sms/2) set these after passing
     // their first tile barrier; secondary CTAs poll these (L2-cached, no NVSwitch).
     int intra_started_flag_offset;

--- a/include/operators/gemm_rs/gemm_rs.cuh
+++ b/include/operators/gemm_rs/gemm_rs.cuh
@@ -766,7 +766,7 @@ void entrypoint_fused(
         add(g_peer_accum_done_count[dev_idx], (size_t)total_chunks * sizeof(uint32_t));
         add(g_chunk_reduce_done[dev_idx], (size_t)total_chunks * sizeof(uint32_t));
         add(g_chunk_accum_lock[dev_idx], (size_t)total_chunks * sizeof(uint32_t));
-        // Grid = one block per region (up to 12); 128 threads/block, strided.
+        // Grid = one block per region (up to 16); 128 threads/block, strided.
         if (regs.n > 0) {
             gemm_rs_fused_zero_kernel<<<dim3((unsigned)regs.n, 1, 1),
                                    dim3(128, 1, 1), 0, stream>>>(regs);

--- a/include/operators/ring_attention/ring_attention.cuh
+++ b/include/operators/ring_attention/ring_attention.cuh
@@ -138,8 +138,8 @@ struct globals {
 // Inter-node KV exchange globals
 // ============================================================================
 //
-// At session bringup kv_send_kernel posts RDMA WRs from every GPU to its
-// same-index counterpart on every remote node. The peers' K/V land in this
+// In the entrypoint prologue kv_send_kernel posts RDMA WRs from every GPU to
+// its same-index counterpart on every remote node. The peers' K/V land in this
 // rank's recv_buf, partitioned into (num_nodes - 1) [K | V] slots.
 //
 // Between rounds, kv_copy_kernel(peer_slot) does:
@@ -151,11 +151,10 @@ struct globals {
 // copied peer KV around the local M-GPU ring just like the round-0 local KV.
 
 struct kv_exchange_globals {
-    bf16 *send_buf;          // registered [K | V] staging buffer
-    // The send buffer (registered with RDMA) holds [K | V] contiguously.
-    // The host stages K0_local→send_buf[0:K_bytes], V0_local→send_buf[K_bytes:]
-    // before launching this kernel. The kernel pushes FIFO commands referencing
-    // local_offset within that send buffer.
+    bf16 *send_buf;          // legacy staging buffer pointer, unused under
+                             // zero-copy send (K0/V0 are RDMA-registered
+                             // directly via DMA-BUF; src_view selects between
+                             // them at the proxy).
     // Base pointer to the receive buffer. At N peers the buffer is laid out
     // as (N-1) consecutive [K | V] slots; the kv_copy kernel takes a peer
     // slot argument and reads from `recv_buf + peer_slot * single_peer_bytes`.
@@ -324,7 +323,7 @@ inline void entrypoint(
         int kv_copy_grid      = n_send + n_copy;
 
 
-        // Prologue: post RDMA WRs so peer-KV transfer overlaps with stages 0-7.
+        // Prologue: post RDMA WRs so peer-KV transfer overlaps with round-0 stages.
         // kv_send/kv_copy don't use dynamic smem — launch with smem=0.
         kv_send_kernel<<<kv_send_grid, config::NUM_THREADS, 0, stream>>>(KE);
         // Match persistent kernel: barrier_all after send, before stages start.

--- a/src/ag_gemm.cu
+++ b/src/ag_gemm.cu
@@ -146,11 +146,11 @@ __device__ inline void intra_comm_sm(const globals& G) {
                 // cheap correctness safeguard and matches how plane-0 flags on
                 // col=0 already ratchet visibility for later cols.
                 //
-                // Inter-comm pushes per-chunk WRs striped across 4 QPs.
-                // Cross-QP arrival is unordered so poll every chunk flag in
-                // each inter rb. One intra tile is 256 rows but RDMA
-                // arrivals are tracked in 128-row blocks — wait for both
-                // halves.
+                // One intra tile is 256 rows but RDMA arrivals are tracked in
+                // 128-row blocks — wait for both halves. Each inter rb is
+                // posted as one WR (WR_SPLIT_CEILING=1) whose completion
+                // raises the first chunk's arrival flag, so polling the
+                // first chunk of each inter rb suffices.
                 const int first_chunk_a = (2 * global_row_idx)     * chunks_per_inter_rb;
                 const int first_chunk_b = (2 * global_row_idx + 1) * chunks_per_inter_rb;
                 ag_gemm_wait_arrival_slot(G, virt_arrival_slot, first_chunk_a);
@@ -241,7 +241,7 @@ __device__ inline comp_task decode_comp_task(int task_id,
         t.rb      = globals::SUPER_M * (flat / super_blocks) + flat % globals::SUPER_M;
         t.col_idx = (flat % super_blocks) / globals::SUPER_M;
     } else {
-        // Unreachable when final_rows==0 (then super_rows==half_row_blocks and
+        // Unreachable when final_rows==0 (then super_rows==node_row_blocks and
         // flat is always < super_tile_limit). Guard with max(1, ...) so the
         // div instruction the compiler emits is well-defined even on dead path.
         const int fr_safe = final_rows > 0 ? final_rows : 1;
@@ -310,10 +310,11 @@ __device__ inline void fused_comp_sm(const globals& G) {
     const int K_val = G.A_local.cols();
     const int chunks_per_rb = max(1, (globals::ROW_BLOCK * K_val * (int)sizeof(bf16)) / CHUNK_BYTES);
 
-    // Task layout: phase-major. task_id < num_local_blocks → local tile;
-    // task_id >= num_local_blocks → remote tile. Within each phase, flat index
-    // is SUPER_M-swizzled over (half_row_blocks × col_blocks). See
-    // decode_comp_task() above for the swizzle math.
+    // Task layout: shard-major. task_id < num_node_blocks → local shard;
+    // task_id >= num_node_blocks → remote shards (one shard per shard_step).
+    // Within each shard, flat index is SUPER_M-swizzled over
+    // (node_row_blocks × col_blocks). See decode_comp_task() above for the
+    // swizzle math.
     const int comp_idx = blockIdx.x - G.num_intra_comm;
 
     if (warpgroup_id == config::NUM_WARPGROUPS - 1) {

--- a/src/dispatch_gemm.cu
+++ b/src/dispatch_gemm.cu
@@ -57,10 +57,10 @@ __device__ inline void fused_inter_send_sm(const fused_globals &G) {
                 internode::TransferCmd cmd{};
                 cmd.cmd_type = internode::CmdType::WRITE;
                 cmd.dst_rank = (uint8_t)peer_rank;
-                cmd.tile_id = (uint16_t)(sap * single_peer_tiles + chunk_id);
+                cmd.tile_id = (uint32_t)(sap * single_peer_tiles + chunk_id);
                 cmd.bytes = bytes;
                 cmd.local_offset = off;
-                cmd.remote_offset = (uint32_t)sap * (uint32_t)single_peer_bytes + off;
+                cmd.remote_offset = (uint64_t)sap * (uint32_t)single_peer_bytes + off;
                 cmd.lane_id = (uint16_t)chunk_id;
                 cmd.reserved0 = (uint8_t)(peer_slot * fused_globals::NUM_DEVICES + G.dev_idx);
                 internode::D2HFifoDevice fifo =

--- a/src/dispatch_gemm.cu
+++ b/src/dispatch_gemm.cu
@@ -157,7 +157,7 @@ __device__ inline void dispatch_fused(const fused_globals &G, const int sm_idx) 
                             // generates IPC/PCIe traffic without reducing
                             // observed latency. 100ns sleep cuts poll rate
                             // ~30x. Mirrors the arrival_flags spin pattern
-                            // in fused_inter_comm_sm.
+                            // in fused_inter_copy_sm.
                             if (v == 1) break;
                             __nanosleep(100);
                         } while (true);
@@ -197,15 +197,7 @@ __device__ inline void dispatch_fused(const fused_globals &G, const int sm_idx) 
     }
 }
 
-// DISPATCH_L2_SWIZZLE: bijective decode of `task_id ∈ [0, row_blocks*col_blocks)`
-// into (row, col) using SUPER_M-grouped traversal. Walks SUPER_M consecutive
-// rows for each col before moving to the next col, then advances to the next
-// SUPER_M-row group. The last partial super-group (when row_blocks % SUPER_M
-// != 0) is handled inline so the bijection covers all task_ids.
-//
-// Goal: improve B-tile (weights) L2 reuse across CTAs in a wave. Likely modest
-// for our shape (col_blocks=8, num_sms=72) since baseline row-major already
-// gives both A and B reuse — confirmed via empirical sweep.
+// Row-major decode of `task_id ∈ [0, row_blocks*col_blocks)` into (row, col).
 __device__ inline void dispatch_swizzle_decode(int task_id, int row_blocks, int col_blocks,
                                           int& row_in_grid, int& col_idx) {
     row_in_grid = task_id / col_blocks;
@@ -228,9 +220,7 @@ __device__ inline void group_gemm_fused(const fused_globals &G, const int sm_idx
             G.padded_tokens_per_expert[{expert_offset + (int)threadIdx.x}];
     // Per-expert count of pure-local row_blocks (first N rb of each expert
     // are all-local under DISPATCH_LOCAL_FIRST). Used by DISPATCH_GEMM_LOCAL_FIRST for
-    // its two-pass schedule, and by DISPATCH_HYBRID_DISPATCH to classify each tile
-    // as pure-local (cp.async gather from pre_tokens) vs peer (TMA from
-    // post_tokens).
+    // its two-pass schedule.
     __shared__ int local_rb_per_expert[fused_globals::NUM_EXPERTS_PER_DEV];
     if (threadIdx.x < fused_globals::NUM_EXPERTS_PER_DEV)
         local_rb_per_expert[threadIdx.x] =
@@ -270,12 +260,7 @@ __device__ inline void group_gemm_fused(const fused_globals &G, const int sm_idx
     if (wg_id == 2) {
         warpgroup::decrease_registers<40>();
         if (w_id == 0) {
-            // Loader warp. Baseline path uses lane 0 for big-TMA A+B loads.
-            // Under DISPATCH_HYBRID_DISPATCH, pure-local row_blocks gather A rows
-            // across all 32 lanes via cp.async (16-byte per lane per iter)
-            // into swizzled SMEM, skipping the post_tokens HBM round-trip.
-            // Peer row_blocks still take the baseline TMA path since those
-            // tokens arrived scattered into post_tokens via dispatch.
+            // Loader warp. Lane 0 issues big-TMA A+B loads.
             #pragma unroll 1
             for (int pass = 0; pass < NUM_PASSES; ++pass) {
                 int task_id = sm_idx;
@@ -424,10 +409,8 @@ __device__ inline void group_gemm_fused(const fused_globals &G, const int sm_idx
 
 // Two-pass dispatch walker, parameterized by (sm_idx, stride).
 // Stride controls how widely workers spread across the per-expert task lists.
-// Real dispatch CTAs use sm_idx ∈ [0, num_dispatch_sms); when DISPATCH_DISPATCH_DONATE_INTER_SEND
-// is on, post-push inter-send CTAs claim virtual sm_idx ∈ [num_dispatch_sms, num_dispatch_sms+num_send_sms)
-// and ALL dispatch workers (real + helpers) use stride = num_dispatch_sms + num_send_sms.
-// Refactored from the inline two-pass walker so both call sites share one body.
+// Real dispatch CTAs use sm_idx ∈ [0, num_dispatch_sms) with stride =
+// num_dispatch_sms.
 __device__ inline void dispatch_two_pass_walk(const fused_globals &G, int sm_idx, int stride) {
     constexpr int SLICES_PER_RB =
         fused_globals::ROW_BLOCK / fused_globals::TOKENS_PER_BLOCK;

--- a/src/gemm_ar.cu
+++ b/src/gemm_ar.cu
@@ -548,14 +548,14 @@ __device__ inline void fused_inter_send_sm(const fused_globals& G) {
                     internode::TransferCmd cmd{};
                     cmd.cmd_type = internode::CmdType::WRITE;
                     cmd.dst_rank = (uint8_t)peer_rank;
-                    cmd.tile_id = (uint16_t)(sap * single_peer_tiles + pack_first_tile);
+                    cmd.tile_id = (uint32_t)(sap * single_peer_tiles + pack_first_tile);
                     cmd.bytes = (uint32_t)((long)group_tiles * TILE_BYTES);
                     cmd.local_offset = offset;
                     cmd.src_view = 0;
                     // Encode the grouped tile count so the proxy can publish all
                     // arrivals covered by this send.
                     cmd.row_count = (uint16_t)group_tiles;
-                    cmd.remote_offset = (uint32_t)((long)sap * single_peer_bytes) + offset;
+                    cmd.remote_offset = (uint64_t)((long)sap * single_peer_bytes) + offset;
                     cmd.lane_id = (uint16_t)(sap * queues_per_peer + logical_q);
                     cmd.reserved0 = (uint8_t)(peer_slot * fused_globals::NUM_DEVICES + G.dev_idx);
                     cmd.enqueue_device_ns = gemm_ar_globaltimer();
@@ -828,10 +828,10 @@ __device__ inline void gemm_ar_post_ring_forward_cmd(
     // Forwarded ring traffic intentionally lands in a caller-selected receive
     // slot instead of the sender's natural peer slot, so reduce-forward and
     // final-forward stages can be distinguished by their arrival bits.
-    cmd.tile_id = (uint16_t)(dst_slot * single_peer_tiles + pack_first_tile);
+    cmd.tile_id = (uint32_t)(dst_slot * single_peer_tiles + pack_first_tile);
     cmd.bytes = (uint32_t)((long)tiles_this_chunk * TILE_BYTES);
     cmd.local_offset = offset;
-    cmd.remote_offset = (uint32_t)((long)dst_slot * single_peer_bytes) + offset;
+    cmd.remote_offset = (uint64_t)((long)dst_slot * single_peer_bytes) + offset;
     cmd.lane_id = (uint16_t)logical_q;
     cmd.src_view = 1; // registered C_remote_accum source for ring path
     cmd.reserved0 = (uint8_t)(G.dev_idx);

--- a/src/gemm_rs.cu
+++ b/src/gemm_rs.cu
@@ -320,10 +320,10 @@ __device__ inline void send_tiles_coalesced(const G &Gv) {
                 internode::TransferCmd cmd{};
                 cmd.cmd_type = internode::CmdType::WRITE;
                 cmd.dst_rank = (uint8_t)peer_rank;
-                cmd.tile_id  = (uint16_t)(sap * single_peer_tiles + chunk_first_tile);
+                cmd.tile_id = (uint32_t)(sap * single_peer_tiles + chunk_first_tile);
                 cmd.bytes    = chunk_bytes;
                 cmd.local_offset = offset;
-                cmd.remote_offset = (uint32_t)((long)sap * single_peer_bytes) + offset;
+                cmd.remote_offset = (uint64_t)((long)sap * single_peer_bytes) + offset;
                 cmd.lane_id  = (uint16_t)(
                     Rt.use_transport_arrival_queue != 0
                         ? (peer_slot * queues_per_peer + logical_q)

--- a/src/ring_attention.cu
+++ b/src/ring_attention.cu
@@ -7,8 +7,9 @@
  * ptxas spills in the attention path:
  *
  *   KV send prologue:
- *     Stages local K/V data and posts RDMA writes to the peer node. It returns
- *     after WRs are queued so network transfer overlaps the early ring stages.
+ *     Stages local K/V data and posts RDMA writes to every remote peer node.
+ *     It returns after WRs are queued so network transfer overlaps the early
+ *     ring stages.
  *
  *   Per-ring comm+partial kernels:
  *     Comm CTAs exchange K/V tiles around the local node while compute CTAs run
@@ -440,10 +441,11 @@ __device__ inline void attn_comm(const globals &G, const int block_idx, const in
 // Layout invariants:
 //   - K0/V0 are row-major contiguous DistBuffers of size K_bytes/V_bytes.
 //   - chunk_id ∈ [0, total_chunks_K) → K side, local_offset = chunk*CHUNK_BYTES
-//     within K0; remote_offset = same (lands at recv_buf[0..K_bytes]).
+//     within K0; remote_offset = sap*single_peer_bytes + chunk*CHUNK_BYTES
+//     (lands at this rank's slot within the peer's recv_buf K region).
 //   - chunk_id ∈ [total_chunks_K, ...) → V side, local_offset = chunk*CHUNK_BYTES
-//     within V0; remote_offset = K_bytes + chunk*CHUNK_BYTES (lands at
-//     recv_buf[K_bytes..K_bytes+V_bytes]).
+//     within V0; remote_offset = sap*single_peer_bytes + K_bytes +
+//     chunk*CHUNK_BYTES (lands in the peer's recv_buf V region for this slot).
 __device__ inline void kv_stage_and_send_sm(const kv_exchange_globals &G) {
     int send_id = blockIdx.x;
     int total_chunks = G.total_chunks_K + G.total_chunks_V;
@@ -648,8 +650,9 @@ void attn_reduction_stage_kernel(
     attn_reduction<false>(G, blockIdx.x);
 }
 
-// Send-only: posts RDMA WRs for local K0/V0 → peer node. Non-blocking; kernel
-// returns once WRs are queued. Used as prologue so RDMA overlaps with stages 0-7.
+// Send-only: posts RDMA WRs for local K0/V0 → every remote peer node.
+// Non-blocking; kernel returns once WRs are queued. Used as prologue so RDMA
+// overlaps with round-0 stages.
 __global__ __launch_bounds__(config::NUM_THREADS, 1)
 void kv_send_kernel(
     const __grid_constant__ kv_exchange_globals KE

--- a/src/ring_attention.cu
+++ b/src/ring_attention.cu
@@ -479,10 +479,10 @@ __device__ inline void kv_stage_and_send_sm(const kv_exchange_globals &G) {
                 internode::TransferCmd cmd{};
                 cmd.cmd_type = internode::CmdType::WRITE;
                 cmd.dst_rank = (uint8_t)peer_rank;
-                cmd.tile_id = (uint16_t)(sap * single_peer_tiles + chunk_id);
+                cmd.tile_id = (uint32_t)(sap * single_peer_tiles + chunk_id);
                 cmd.bytes = bytes;
                 cmd.local_offset = off;
-                cmd.remote_offset = (uint32_t)sap * (uint32_t)single_peer_bytes + remote_off;
+                cmd.remote_offset = (uint64_t)sap * (uint32_t)single_peer_bytes + remote_off;
                 cmd.src_view = src_view;
                 cmd.lane_id = (uint16_t)chunk_id;
                 cmd.reserved0 = (uint8_t)(peer_slot * globals::NUM_DEVICES + G.dev_idx);
@@ -525,10 +525,10 @@ __device__ inline void kv_send_sm(const kv_exchange_globals &G) {
                     internode::TransferCmd cmd{};
                     cmd.cmd_type = internode::CmdType::WRITE;
                     cmd.dst_rank = (uint8_t)peer_rank;
-                    cmd.tile_id  = (uint16_t)(sap * single_peer_tiles + chunk_id);
+                    cmd.tile_id = (uint32_t)(sap * single_peer_tiles + chunk_id);
                     cmd.bytes    = bytes;
                     cmd.local_offset  = off;
-                    cmd.remote_offset = (uint32_t)sap * (uint32_t)single_peer_bytes + off;
+                    cmd.remote_offset = (uint64_t)sap * (uint32_t)single_peer_bytes + off;
                     cmd.lane_id = (uint16_t)chunk_id;
                     cmd.reserved0 = (uint8_t)(peer_slot * globals::NUM_DEVICES + G.dev_idx);
                     internode::D2HFifoDevice fifo =
@@ -546,10 +546,10 @@ __device__ inline void kv_send_sm(const kv_exchange_globals &G) {
                     internode::TransferCmd cmd{};
                     cmd.cmd_type = internode::CmdType::WRITE;
                     cmd.dst_rank = (uint8_t)peer_rank;
-                    cmd.tile_id  = (uint16_t)(sap * single_peer_tiles + chunk_id);
+                    cmd.tile_id = (uint32_t)(sap * single_peer_tiles + chunk_id);
                     cmd.bytes    = bytes;
-                    cmd.local_offset  = (uint32_t)(G.K_bytes) + off;
-                    cmd.remote_offset = (uint32_t)sap * (uint32_t)single_peer_bytes
+                    cmd.local_offset = (uint64_t)(G.K_bytes) + off;
+                    cmd.remote_offset = (uint64_t)sap * (uint32_t)single_peer_bytes
                                         + (uint32_t)(G.K_bytes) + off;
                     cmd.lane_id = (uint16_t)chunk_id;
                     cmd.reserved0 = (uint8_t)(peer_slot * globals::NUM_DEVICES + G.dev_idx);


### PR DESCRIPTION
At N≥3 nodes with large shapes, three fields in `TransferCmd` (the GPU→host FIFO command) were silently overflowing for the 2nd and 3rd remote peers:

  - `tile_id` (uint16_t): overflowed once `slot_at_peer × single_peer_tiles ≥ 65536`
    Reduce CTAs polled arrival flags that the proxy never wrote → kernel hang.

  - `remote_offset` (uint32_t): overflowed once `slot_at_peer × single_peer_bytes ≥ 4 GiB`

  - `local_offset` (uint32_t): the same overflow in the ag_gemm

  - ag_gemm also had explicit `(uint32_t)source_slot * (uint32_t)a_half_bytes` casts in `post_ring_forward_wrs_for_intra_row` that overflowed at M=49152 emulated 4×4 (destination virtual slot up to 8 × ~1.13 GiB > 4 GiB).