### PR TITLE
[Multinode] Fix ForwardNotify offset width

### DIFF
--- a/include/comm/internode/proxy.h
+++ b/include/comm/internode/proxy.h
@@ -791,7 +791,6 @@ private:
             n.src_view = src.src_view;
             n.epoch = src.epoch;
             n.reserved1 = src.reserved1;
-            n.reserved2 = src.reserved2;
             if (n.epoch != cfg_.epoch) continue;
             if (n.tile_id != (uint32_t)slot) continue;
             TransferCmd fwd = make_forward_cmd_from_notify(n);

--- a/include/comm/internode/types.h
+++ b/include/comm/internode/types.h
@@ -58,14 +58,13 @@ static_assert(sizeof(TransferCmd) == 48, "TransferCmd must be exactly 48 bytes")
 #pragma pack(push, 1)
 struct ForwardNotify {
     uint32_t bytes;
-    uint32_t local_offset;   // offset in the receiver's local_data MR
+    uint64_t local_offset;   // offset in the receiver's local_data MR
     uint32_t tile_id;        // arrival slot that just became ready
     uint16_t lane_id;
     uint8_t  reserved0;
     uint8_t  src_view;
     uint32_t epoch;          // written last in the source struct before RDMA
     uint64_t reserved1;
-    uint32_t reserved2;
 };
 #pragma pack(pop)
 


### PR DESCRIPTION
## Summary
- widen `ForwardNotify::local_offset` to 64-bit so it matches the offset width carried by `TransferCmd`
- remove the stale `reserved2` copy from the proxy snapshot path after the struct layout change

## Why
CUDA 13 rejects the existing aggregate initialization because `cmd.remote_offset` is 64-bit while `ForwardNotify::local_offset` was 32-bit. The forwarding path later rebuilds a `TransferCmd` from the notify payload, so the notify offset should carry the same 64-bit byte offset. Removing the old padding copy keeps the proxy in sync with the updated 32-byte `ForwardNotify` layout.
