### PR TITLE
Add peermem-compatible RDMA backing

### DIFF
--- a/bench/ag_gemm_bench.py
+++ b/bench/ag_gemm_bench.py
@@ -22,6 +22,10 @@ from common import (  # noqa: E402
     gather_cpu_tensors,
     get_peer_ips,
     get_peer_ports,
+    is_peermem_backing,
+    make_dist_buffer,
+    rdma_backing,
+    rdma_policy_label,
 )
 
 KERNEL_NAME = "ag_gemm"
@@ -108,8 +112,12 @@ def main():
     tcp_port = int(os.environ.get("TCP_PORT", "19790")) + local_rank
 
     mod = load_module.load(KERNEL_NAME)
+    source_backing = rdma_backing()
+    target_backing = source_backing
     if is_chief:
         print(f"[ag_gemm] world={world_size*NUM_NODES} shapes={args.shapes}", flush=True)
+        print(rdma_policy_label(
+            KERNEL_NAME, source=source_backing, target=target_backing), flush=True)
 
     shapes = [int(x) for x in args.shapes.split(",") if x.strip()]
     global_world = NUM_NODES * world_size
@@ -193,9 +201,27 @@ def main():
         start_row = local_rank * M_local
         a_tk.data_[start_row:start_row + M_local].copy_(A_local)
 
+        a_rdma_src = None
+        if is_peermem_backing(source_backing):
+            a_rdma_src = make_dist_buffer(
+                mod, (M_node, K), dtype=torch.bfloat16,
+                local_rank=local_rank, local_world_size=world_size,
+                multicast=False, backing=source_backing)
+            a_rdma_src.data_.zero_()
+            a_rdma_src.data_[start_row:start_row + M_local].copy_(A_local)
+
         a_recv_tk = mod.DistBuffer((M_node * n_peers * ring_recv_banks, K), dtype=torch.bfloat16,
             local_rank=local_rank, local_world_size=world_size, multicast=True)
         a_recv_tk.data_.zero_()
+
+        a_recv_rdma = None
+        if is_peermem_backing(target_backing):
+            a_recv_rdma = make_dist_buffer(
+                mod, (M_node * n_peers * ring_recv_banks, K),
+                dtype=torch.bfloat16,
+                local_rank=local_rank, local_world_size=world_size,
+                multicast=False, backing=target_backing)
+            a_recv_rdma.data_.zero_()
 
         barrier = mod.DistBuffer((3, 1024, 1024), dtype=torch.int,
             local_rank=local_rank, local_world_size=world_size, multicast=True)
@@ -214,8 +240,8 @@ def main():
         dist.barrier()
         fifo_cap = 2048
         while fifo_cap < recv_buf_chunks * 2: fifo_cap *= 2
-        a_tk_ptr = int(a_tk.data_.data_ptr())
-        send_buf_ptr = int(a_recv_tk.data_.data_ptr())
+        a_tk_ptr = int((a_rdma_src if a_rdma_src is not None else a_tk).data_.data_ptr())
+        send_buf_ptr = int((a_recv_rdma if a_recv_rdma is not None else a_recv_tk).data_.data_ptr())
         send_buf_size = recv_buf_bytes
         # A_recv is registered as MR0 (src_view=0) so received shards can be
         # forwarded to the next node after phase-2 republishes them.
@@ -239,11 +265,17 @@ def main():
         def reset_state():
             barrier.data_.zero_()
             a_tk.data_[start_row:start_row + M_local].copy_(A_local)
+            if a_rdma_src is not None:
+                a_rdma_src.data_.zero_()
+                a_rdma_src.data_[start_row:start_row + M_local].copy_(A_local)
             a_recv_tk.data_.zero_()
+            if a_recv_rdma is not None:
+                a_recv_rdma.data_.zero_()
             C.zero_()
 
         def run_once():
-            active_sms = int(os.environ.get("AG_GEMM_ACTIVE_SMS", "132"))
+            default_active_sms = torch.cuda.get_device_properties(local_rank).multi_processor_count
+            active_sms = int(os.environ.get("AG_GEMM_ACTIVE_SMS", str(default_active_sms)))
             mod.ag_gemm_multinode(
                 a_tk, B, C, barrier,
                 recv_ptr,

--- a/bench/common.py
+++ b/bench/common.py
@@ -24,6 +24,58 @@ import load_module  # noqa: E402
 
 
 # ----------------------------------------------------------------------
+# RDMA buffer backing policy
+# ----------------------------------------------------------------------
+
+def rdma_backing(*, default: str = "vmm") -> str:
+    """Resolve the global RDMA buffer backing.
+
+    Precedence, high to low:
+      MKERNEL_RDMA_BUFFER_BACKING
+      default
+    """
+    raw = os.environ.get("MKERNEL_RDMA_BUFFER_BACKING", default)
+    backing = raw.strip().lower()
+    if backing not in ("vmm", "peermem"):
+        raise ValueError(
+            f"Unsupported RDMA backing {raw!r}; expected 'vmm' or 'peermem'")
+    return backing
+
+
+def is_peermem_backing(backing: str) -> bool:
+    return backing == "peermem"
+
+
+def make_dist_buffer(
+    mod,
+    shape,
+    *,
+    dtype,
+    local_rank: int,
+    local_world_size: int,
+    multicast: bool = False,
+    backing: str = "vmm",
+):
+    """Create a DistBuffer from the generic RDMA backing policy."""
+    if backing not in ("vmm", "peermem"):
+        raise ValueError(
+            f"Unsupported RDMA backing {backing!r}; expected 'vmm' or 'peermem'")
+    if multicast and backing == "peermem":
+        raise ValueError("peermem RDMA backing does not support multicast")
+    return mod.DistBuffer(
+        shape, dtype=dtype,
+        local_rank=local_rank, local_world_size=local_world_size,
+        multicast=multicast,
+        backing="cuda_malloc" if backing == "peermem" else "vmm",
+    )
+
+
+def rdma_policy_label(kernel: str, **roles: str) -> str:
+    parts = " ".join(f"{k}={v}" for k, v in roles.items())
+    return f"[{kernel}] rdma_backing {parts}"
+
+
+# ----------------------------------------------------------------------
 # Distributed init / launcher helpers
 # ----------------------------------------------------------------------
 

--- a/bench/dispatch_gemm_bench.py
+++ b/bench/dispatch_gemm_bench.py
@@ -36,6 +36,9 @@ from common import (  # noqa: E402
     gather_cpu_tensors,
     get_peer_ips,
     get_peer_ports,
+    make_dist_buffer,
+    rdma_backing,
+    rdma_policy_label,
 )
 
 KERNEL_NAME = "dispatch_gemm"
@@ -222,10 +225,14 @@ def main():
     tcp_port = int(os.environ.get("TCP_PORT", "19790")) + local_rank
 
     mod = load_module.load(KERNEL_NAME)
+    source_backing = rdma_backing()
+    target_backing = source_backing
 
     if is_chief:
         print(f"[dispatch_gemm] world={world_size*NUM_NODES} per_node={world_size} "
               f"shapes={args.shapes}", flush=True)
+        print(rdma_policy_label(
+            KERNEL_NAME, source=source_backing, target=target_backing), flush=True)
 
     shapes = [int(x) for x in args.shapes.split(",") if x.strip()]
     total_gpus = NUM_NODES * world_size
@@ -297,16 +304,20 @@ def main():
             / (H ** 0.25)
         )
 
-        pre_tokens = mod.DistBuffer(
+        pre_tokens = make_dist_buffer(
+            mod,
             (num_local_tokens, H), dtype=torch.bfloat16,
             local_rank=local_rank, local_world_size=world_size, multicast=False,
+            backing=source_backing,
         )
         pre_tokens.data_.copy_(pre_tokens_data)
 
         n_peers = NUM_NODES - 1
-        peer_tokens = mod.DistBuffer(
+        peer_tokens = make_dist_buffer(
+            mod,
             (n_peers * num_local_tokens, H), dtype=torch.bfloat16,
             local_rank=local_rank, local_world_size=world_size, multicast=False,
+            backing=target_backing,
         )
         peer_tokens.data_.zero_()
 

--- a/bench/gemm_rs_bench.py
+++ b/bench/gemm_rs_bench.py
@@ -24,6 +24,9 @@ from common import (  # noqa: E402
     compare_named_results,
     get_peer_ips,
     get_peer_ports,
+    make_dist_buffer,
+    rdma_backing,
+    rdma_policy_label,
 )
 
 KERNEL_NAME = "gemm_rs"
@@ -221,13 +224,18 @@ def main():
         )
         ready_chunk.data_.zero_()
 
-        # GEMM_RS_INTRA_RS_DIRECT_STAGING=1: staging is a DistBuffer.
-        staging_dbuf = mod.DistBuffer(
+        # The staging buffer is the RDMA source for GEMM_RS.
+        staging_backing = rdma_backing()
+        staging_dbuf = make_dist_buffer(
+            mod,
             (m_local, n), dtype=torch.bfloat16,
-            local_rank=local_rank, local_world_size=world_size, multicast=False,
+            local_rank=local_rank, local_world_size=world_size,
+            multicast=False, backing=staging_backing,
         )
         staging_dbuf.data_.zero_()
         staging_buf = staging_dbuf.data_
+        if is_chief:
+            print(rdma_policy_label(KERNEL_NAME, source=staging_backing), flush=True)
 
         os.environ["GEMM_RS_RDMA_CHUNK_TILES_RT"] = str(chunk_tiles)
 

--- a/bench/ring_attention_bench.py
+++ b/bench/ring_attention_bench.py
@@ -23,6 +23,10 @@ from common import (  # noqa: E402
     gather_cpu_tensors,
     get_peer_ips,
     get_peer_ports,
+    is_peermem_backing,
+    make_dist_buffer,
+    rdma_backing,
+    rdma_policy_label,
 )
 
 KERNEL_NAME = "ring_attention"
@@ -86,9 +90,15 @@ def main():
     tcp_port = int(os.environ.get("TCP_PORT", "18560")) + local_rank
 
     mod = load_module.load(KERNEL_NAME)
+    source_backing = rdma_backing()
+    rdma_source_staging = is_peermem_backing(source_backing)
+    ring_buffer_backing = "vmm" if rdma_source_staging else source_backing
     if is_chief:
         print(f"[ring_attn] world={world_size} per_node={local_world_size} "
               f"shapes={args.shapes}", flush=True)
+        print(rdma_policy_label(
+            KERNEL_NAME, source=source_backing, target="cuda_malloc",
+            ring=ring_buffer_backing), flush=True)
 
     seqs = [int(x) for x in args.shapes.split(",") if x.strip()]
     global_gpu = node_idx * local_world_size + local_rank
@@ -124,10 +134,11 @@ def main():
                               dtype=torch.bfloat16) * scale
 
         def dbuf(shape):
-            return mod.DistBuffer(
+            return make_dist_buffer(
+                mod,
                 shape, dtype=torch.bfloat16,
                 local_rank=local_rank, local_world_size=local_world_size,
-                multicast=False)
+                multicast=False, backing=ring_buffer_backing)
 
         K0 = dbuf((BATCH, HEADS, seq_per_dev, D))
         K1 = dbuf((BATCH, HEADS, seq_per_dev, D))
@@ -147,7 +158,15 @@ def main():
         k_bytes = K_local.numel() * 2
         v_bytes = V_local.numel() * 2
         kv_buf_bytes = k_bytes + v_bytes
-        send_buf = torch.empty(kv_buf_bytes // 2, device="cuda", dtype=torch.bfloat16)
+        send_staging = None
+        if rdma_source_staging:
+            send_staging = make_dist_buffer(
+                mod, (kv_buf_bytes // 2,), dtype=torch.bfloat16,
+                local_rank=local_rank, local_world_size=local_world_size,
+                multicast=False, backing=source_backing)
+            send_buf = send_staging.data_
+        else:
+            send_buf = torch.empty(kv_buf_bytes // 2, device="cuda", dtype=torch.bfloat16)
         send_buf_ptr = send_buf.data_ptr()
         total_chunks = (kv_buf_bytes + CHUNK_BYTES - 1) // CHUNK_BYTES
 
@@ -160,8 +179,8 @@ def main():
         fifo_cap = 2048
         while fifo_cap < recv_buf_chunks * 2: fifo_cap *= 2
 
-        # Zero-copy send: K0 and V0 are registered as DMA-BUF MRs. Proxy
-        # posts single-SGE WRs straight from the VMM tensors — no pack.
+        # Default zero-copy send registers K0/V0 directly. Peermem mode keeps
+        # those as VMM ring buffers and registers send_staging instead.
         peer_ips = get_peer_ips(node_idx, NUM_NODES)
         mod.create_session(
             node_idx, peer_ip, tcp_port,
@@ -169,6 +188,7 @@ def main():
             recv_buf_chunks, fifo_cap, local_rank,
             int(K0.data_.data_ptr()), k_bytes,
             int(V0.data_.data_ptr()), v_bytes,
+            rdma_source_staging,
             peer_ips=peer_ips,
             peer_tcp_ports=get_peer_ports(node_idx, NUM_NODES, tcp_port),
         )
@@ -176,8 +196,15 @@ def main():
         arrival_ptr = mod.get_arrival_flags_ptr()
         recv_ptr = mod.get_recv_buf_ptr()
 
+        def pack_send_staging():
+            if send_staging is None:
+                return
+            send_buf[:k_bytes // 2].copy_(K_local.reshape(-1))
+            send_buf[k_bytes // 2:].copy_(V_local.reshape(-1))
+
         K0.data_.copy_(K_local); V0.data_.copy_(V_local)
         K1.data_.zero_(); V1.data_.zero_()
+        pack_send_staging()
         barrier.data_.zero_()
 
         epoch = 1
@@ -187,6 +214,7 @@ def main():
         def reset_and_run(ep):
             K0.data_.copy_(K_local); V0.data_.copy_(V_local)
             K1.data_.zero_(); V1.data_.zero_()
+            pack_send_staging()
             barrier.data_.zero_()
             L.zero_(); L_block.zero_()
             O.zero_(); O_block.zero_()
@@ -199,6 +227,7 @@ def main():
                 arrival_ptr, ep,
                 node_idx, args.num_comm_sms,
                 args.num_send_sms, args.num_copy_sms, NUM_NODES,
+                rdma_source_staging,
             )
 
         for _ in range(args.warmup + 1):
@@ -216,6 +245,8 @@ def main():
         legacy_sync = os.environ.get("MKERNEL_BENCH_LEGACY_SYNC") == "1"
         if os.environ.get("MKERNEL_BENCH_NO_SYNC") == "0":
             legacy_sync = True
+        if rdma_source_staging:
+            legacy_sync = True
         if not legacy_sync:
             # Pick N so total ≥ ~100 ms at smaller shapes but bounded ≤ ~2s at
             # the largest. For ring_attn, expected per-iter ms ≈ shape-dependent
@@ -230,6 +261,7 @@ def main():
             epoch += 1
             K0.data_.copy_(K_local); V0.data_.copy_(V_local)
             K1.data_.zero_(); V1.data_.zero_()
+            pack_send_staging()
             barrier.data_.zero_()
             L.zero_(); L_block.zero_(); O.zero_(); O_block.zero_()
             mod.set_epoch(epoch)
@@ -246,6 +278,7 @@ def main():
                     arrival_ptr, epoch,
                     node_idx, args.num_comm_sms,
                     args.num_send_sms, args.num_copy_sms, NUM_NODES,
+                    rdma_source_staging,
                 )
             e.record()
             torch.cuda.synchronize()
@@ -260,6 +293,7 @@ def main():
                 epoch += 1
                 K0.data_.copy_(K_local); V0.data_.copy_(V_local)
                 K1.data_.zero_(); V1.data_.zero_()
+                pack_send_staging()
                 barrier.data_.zero_()
                 L.zero_(); L_block.zero_(); O.zero_(); O_block.zero_()
                 mod.set_epoch(epoch)
@@ -274,6 +308,7 @@ def main():
                     arrival_ptr, epoch,
                     node_idx, args.num_comm_sms,
                     args.num_send_sms, args.num_copy_sms, NUM_NODES,
+                    rdma_source_staging,
                 )
                 e.record(); torch.cuda.synchronize()
                 samples.append(s.elapsed_time(e))

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -106,7 +106,7 @@ COMMON_ENV=(
     "INTERNODE_BACKEND=$BACKEND"
     "LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}"
     "NCCL_IB_DISABLE=${NCCL_IB_DISABLE:-1}"
-    "NCCL_P2P_DISABLE=0"
+    "NCCL_P2P_DISABLE=${NCCL_P2P_DISABLE:-0}"
     "NCCL_SOCKET_IFNAME=${NCCL_SOCKET_IFNAME:-enp71s0}"
     "NCCL_SOCKET_FAMILY=${NCCL_SOCKET_FAMILY:-AF_INET}"
     "NCCL_IB_ADDR_FAMILY=${NCCL_IB_ADDR_FAMILY:-AF_INET}"
@@ -125,6 +125,11 @@ COMMON_ENV=(
     "NUM_NODES=$NUM_NODES"
     "MKERNEL_H200=${MKERNEL_H200:-0}"
 )
+for var in NCCL_SHM_DISABLE NCCL_CUMEM_HOST_ENABLE NCCL_CUMEM_ENABLE; do
+    if [[ -n "${!var:-}" ]]; then
+        COMMON_ENV+=("${var}=${!var}")
+    fi
+done
 for ((i=0; i<NUM_NODES; i++)); do
     ip_var="NODE${i}_IP"
     COMMON_ENV+=("${ip_var}=${!ip_var}")
@@ -291,6 +296,10 @@ run_one_2node() {
     if [[ -n "${MKERNEL_BENCH_LEGACY_SYNC:-}" ]]; then
         env_str="$env_str MKERNEL_BENCH_LEGACY_SYNC=$MKERNEL_BENCH_LEGACY_SYNC"
     fi
+    # Generic RDMA buffer backing policy, e.g. MKERNEL_RDMA_BUFFER_BACKING=peermem.
+    for var in $(compgen -e | grep -E '^MKERNEL_RDMA_BUFFER_BACKING$' || true); do
+        env_str="$env_str ${var}=${!var}"
+    done
     if [[ "$allow_profiler_logging" == "1" && -n "${MKERNEL_BENCH_DUMP_RANK_MS:-}" ]]; then
         env_str="$env_str MKERNEL_BENCH_DUMP_RANK_MS=$MKERNEL_BENCH_DUMP_RANK_MS"
     fi

--- a/include/comm/internode/rdma_gpu_mr.cuh
+++ b/include/comm/internode/rdma_gpu_mr.cuh
@@ -18,6 +18,7 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <unistd.h>
 
 namespace internode {
 namespace gpu_mr {
@@ -30,6 +31,42 @@ namespace gpu_mr {
 static constexpr int kDefaultAccess =
     IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ
     | IBV_ACCESS_RELAXED_ORDERING;
+
+inline ibv_mr* reg_dmabuf_mr_with_retry(
+    ibv_pd* pd, uint64_t offset, size_t bytes, uint64_t iova, int fd, int access) {
+    errno = 0;
+    ibv_mr* mr = ibv_reg_dmabuf_mr(pd, offset, bytes, iova, fd, access);
+    if (mr != nullptr) return mr;
+
+    const int first_errno = errno;
+    if ((access & IBV_ACCESS_RELAXED_ORDERING) != 0) {
+        const int fallback_access = access & ~IBV_ACCESS_RELAXED_ORDERING;
+        errno = 0;
+        mr = ibv_reg_dmabuf_mr(pd, offset, bytes, iova, fd, fallback_access);
+        if (mr != nullptr) return mr;
+        const int retry_errno = errno;
+        errno = retry_errno != 0 ? retry_errno : first_errno;
+    }
+    return nullptr;
+}
+
+inline ibv_mr* reg_mr_with_retry(
+    ibv_pd* pd, void* addr, size_t bytes, int access) {
+    errno = 0;
+    ibv_mr* mr = ibv_reg_mr(pd, addr, bytes, access);
+    if (mr != nullptr) return mr;
+
+    const int first_errno = errno;
+    if ((access & IBV_ACCESS_RELAXED_ORDERING) != 0) {
+        const int fallback_access = access & ~IBV_ACCESS_RELAXED_ORDERING;
+        errno = 0;
+        mr = ibv_reg_mr(pd, addr, bytes, fallback_access);
+        if (mr != nullptr) return mr;
+        const int retry_errno = errno;
+        errno = retry_errno != 0 ? retry_errno : first_errno;
+    }
+    return nullptr;
+}
 
 /**
  * Register an existing GPU buffer for RDMA.
@@ -56,7 +93,8 @@ inline ibv_mr* register_gpu_buffer(ibv_pd* pd, void* gpu_ptr, size_t bytes,
             &fd, (CUdeviceptr)gpu_ptr, bytes,
             CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, 0);
         if (cu_err == CUDA_SUCCESS && fd >= 0) {
-            mr = ibv_reg_dmabuf_mr(pd, 0, bytes, (uint64_t)gpu_ptr, fd, access);
+            mr = reg_dmabuf_mr_with_retry(
+                pd, 0, bytes, (uint64_t)gpu_ptr, fd, access);
             close(fd);
             if (mr) {
                 return mr;
@@ -75,7 +113,8 @@ inline ibv_mr* register_gpu_buffer(ibv_pd* pd, void* gpu_ptr, size_t bytes,
             cu_err = cuMemExportToShareableHandle(&fd, alloc_handle,
                          CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0);
             if (cu_err == CUDA_SUCCESS && fd >= 0) {
-                mr = ibv_reg_dmabuf_mr(pd, 0, bytes, (uint64_t)gpu_ptr, fd, access);
+                mr = reg_dmabuf_mr_with_retry(
+                    pd, 0, bytes, (uint64_t)gpu_ptr, fd, access);
                 close(fd);
                 if (mr) {
                     return mr;
@@ -87,10 +126,11 @@ inline ibv_mr* register_gpu_buffer(ibv_pd* pd, void* gpu_ptr, size_t bytes,
     }
 
     // --- Path 2: nvidia_peermem fallback ---
-    mr = ibv_reg_mr(pd, gpu_ptr, bytes, access);
+    mr = reg_mr_with_retry(pd, gpu_ptr, bytes, access);
     if (!mr) {
         fprintf(stderr, "rdma_gpu_mr: ibv_reg_mr(gpu) failed: %s\n"
-                "Is nvidia_peermem loaded? (lsmod | grep nvidia_peermem)\n",
+                "Is nvidia_peermem or nv_peer_mem loaded? "
+                "(lsmod | grep -E 'nvidia_peermem|nv_peer_mem')\n",
                 strerror(errno));
         exit(EXIT_FAILURE);
     }
@@ -121,7 +161,8 @@ inline ibv_mr* register_gpu_buffer_dmabuf_only(
             &fd, (CUdeviceptr)gpu_ptr, bytes,
             CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, 0);
         if (cu_err == CUDA_SUCCESS && fd >= 0) {
-            ibv_mr* mr = ibv_reg_dmabuf_mr(pd, 0, bytes, (uint64_t)gpu_ptr, fd, access);
+            ibv_mr* mr = reg_dmabuf_mr_with_retry(
+                pd, 0, bytes, (uint64_t)gpu_ptr, fd, access);
             close(fd);
             if (mr) {
                 if (path_out) *path_out = "addr_range";
@@ -149,7 +190,8 @@ inline ibv_mr* register_gpu_buffer_dmabuf_only(
                 &fd, alloc_handle,
                 CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0);
             if (cu_err == CUDA_SUCCESS && fd >= 0) {
-                ibv_mr* mr = ibv_reg_dmabuf_mr(pd, 0, bytes, (uint64_t)gpu_ptr, fd, access);
+                ibv_mr* mr = reg_dmabuf_mr_with_retry(
+                    pd, 0, bytes, (uint64_t)gpu_ptr, fd, access);
                 close(fd);
                 if (mr) {
                     if (path_out) *path_out = "retain";

--- a/include/comm/internode/session.h
+++ b/include/comm/internode/session.h
@@ -177,11 +177,11 @@ struct SessionConfig {
     void*       local_gpu_buf;       // existing GPU buffer to register for RDMA reads
     size_t      local_gpu_buf_size;  // size of local_gpu_buf
 
-    // Optional second buffer to register as a DMA-BUF MR (for direct-from-
-    // C_local sends that bypass the staging copy). Required when
-    // direct_dmabuf_enabled is true. Must point to a VMM-backed allocation
-    // (DistBuffer::data_). Registration uses ibv_reg_dmabuf_mr only —
-    // no nvidia_peermem / ibv_reg_mr fallback.
+    // Optional second buffer to register for direct GPU sends that bypass the
+    // staging copy. Required when direct_dmabuf_enabled is true. Registration
+    // uses the common GPU-MR path: DMA-BUF first, then ibv_reg_mr through
+    // nvidia_peermem/nv_peer_mem. VMM allocations still require DMA-BUF
+    // support; cudaMalloc-backed buffers can use the peermem fallback.
     void*       clocal_gpu_buf = nullptr;
     size_t      clocal_gpu_buf_size = 0;
     bool        direct_dmabuf_enabled = false;
@@ -237,14 +237,15 @@ struct Session {
     // Local data buffer MR (registered over caller's existing GPU buffer)
     ibv_mr*       local_data_mr;
 
-    // Optional DMA-BUF MR over the C_local (DistBuffer data_) buffer.
-    // Non-null only when SessionConfig::direct_dmabuf_enabled was set and the
-    // strict DMA-BUF registration succeeded.
+    // Optional direct GPU MR over the C_local (DistBuffer data_) buffer.
+    // Non-null only when SessionConfig::direct_dmabuf_enabled was set and GPU
+    // memory registration succeeded.
     ibv_mr*       clocal_data_mr = nullptr;
 
     // Receive buffer (allocated on GPU, RDMA-registered for remote writes)
     gpu_mr::GpuRdmaBuffer recv_buf;
     bool          recv_buf_external = false;
+    bool          recv_buf_aliases_local_data = false;
 
     // D2H command FIFOs — one per proxy thread / FIFO channel.
     D2HFifoPair   fifos[kMaxProxyThreads];
@@ -387,22 +388,23 @@ inline Session* create_session(const SessionConfig& cfg) {
         exit(EXIT_FAILURE);
     }
 
-    // Optional: DMA-BUF-only registration of C_local (direct-send MR).
+    // Optional direct-send registration of C_local. The registration helper
+    // prefers DMA-BUF and falls back to nvidia_peermem/nv_peer_mem for
+    // cudaMalloc-backed buffers.
     if (cfg.direct_dmabuf_enabled) {
         if (cfg.clocal_gpu_buf == nullptr || cfg.clocal_gpu_buf_size == 0) {
             fprintf(stderr,
                     "session: direct_dmabuf_enabled but clocal_gpu_buf not provided\n");
             exit(EXIT_FAILURE);
         }
-        s->clocal_data_mr = gpu_mr::register_gpu_buffer_dmabuf_only(
+        s->clocal_data_mr = gpu_mr::register_gpu_buffer(
             s->pd, cfg.clocal_gpu_buf, cfg.clocal_gpu_buf_size,
             IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ
-            | IBV_ACCESS_RELAXED_ORDERING,
-            nullptr);
+            | IBV_ACCESS_RELAXED_ORDERING);
         if (!s->clocal_data_mr) {
             fprintf(stderr,
-                    "session: DMA-BUF-only registration of C_local failed "
-                    "(ptr=%p bytes=%zu). No peermem fallback permitted — exiting.\n",
+                    "session: direct GPU registration of C_local failed "
+                    "(ptr=%p bytes=%zu).\n",
                     cfg.clocal_gpu_buf, cfg.clocal_gpu_buf_size);
             exit(EXIT_FAILURE);
         }
@@ -412,8 +414,13 @@ inline Session* create_session(const SessionConfig& cfg) {
     if (cfg.external_recv_buf != nullptr) {
         s->recv_buf.gpu_ptr = cfg.external_recv_buf;
         s->recv_buf.size = cfg.recv_buf_size;
-        s->recv_buf.mr = gpu_mr::register_gpu_buffer(
-            s->pd, s->recv_buf.gpu_ptr, s->recv_buf.size);
+        s->recv_buf_aliases_local_data =
+            cfg.external_recv_buf == cfg.local_gpu_buf &&
+            cfg.recv_buf_size == cfg.local_gpu_buf_size;
+        s->recv_buf.mr = s->recv_buf_aliases_local_data
+            ? s->local_data_mr
+            : gpu_mr::register_gpu_buffer(
+                s->pd, s->recv_buf.gpu_ptr, s->recv_buf.size);
         s->recv_buf_external = true;
     } else {
         s->recv_buf = gpu_mr::alloc_and_register(
@@ -739,7 +746,9 @@ inline void destroy_session(Session* s) {
 
     // Free buffers
     if (s->recv_buf_external) {
-        if (s->recv_buf.mr) rdma::dereg_mr(s->recv_buf.mr);
+        if (!s->recv_buf_aliases_local_data && s->recv_buf.mr) {
+            rdma::dereg_mr(s->recv_buf.mr);
+        }
         s->recv_buf = gpu_mr::GpuRdmaBuffer{};
     } else {
         gpu_mr::free_buffer(s->recv_buf);

--- a/include/comm/internode/session_efa.h
+++ b/include/comm/internode/session_efa.h
@@ -206,6 +206,7 @@ struct Session {
     // Receive buffer (allocated on GPU, RDMA-registered for remote writes).
     // Registered on every rail's PD; the per-rail MRs live in rails[r].recv_buf_mr.
     gpu_mr::GpuRdmaBuffer recv_buf;
+    bool          recv_buf_aliases_local_data = false;
 
     // D2H command FIFOs (one per proxy thread / FIFO channel).
     D2HFifoPair         fifos[kMaxProxyThreads];
@@ -381,12 +382,18 @@ inline Session* create_session(const SessionConfig& cfg) {
             s->rails[r].pd, cfg.local_gpu_buf, cfg.local_gpu_buf_size);
     }
 
-    // Optional: register the direct-send GPU source buffer (e.g.
-    // output_local) as a DMA-BUF MR on every rail's PD. Skipping the staging
-    // pack + gather on the send critical path. Hard-fails if DMA-BUF export
-    // is unavailable — callers opt in explicitly.
-    if (cfg.direct_dmabuf_enabled && cfg.clocal_gpu_buf != nullptr
-        && cfg.clocal_gpu_buf_size > 0) {
+    // Optional: register the direct-send GPU source buffer (e.g. output_local)
+    // as a DMA-BUF MR on every rail's PD. Skips the staging pack + gather on
+    // the send critical path. EFA keeps this DMA-BUF-only; peermem fallback is
+    // intentionally scoped to the CX7/RoCE backend.
+    if (cfg.direct_dmabuf_enabled) {
+        if (cfg.clocal_gpu_buf == nullptr || cfg.clocal_gpu_buf_size == 0) {
+            fprintf(stderr,
+                "session_efa: direct-DMA-BUF MR requested but clocal_gpu_buf is missing "
+                "(ptr=%p bytes=%zu).\n",
+                cfg.clocal_gpu_buf, cfg.clocal_gpu_buf_size);
+            exit(EXIT_FAILURE);
+        }
         for (int r = 0; r < num_rails; r++) {
             const char* path = nullptr;
             s->rails[r].clocal_data_mr = gpu_mr::register_gpu_buffer_dmabuf_only(
@@ -415,11 +422,20 @@ inline Session* create_session(const SessionConfig& cfg) {
         s->recv_buf.size = cfg.recv_buf_size;
         s->recv_buf.mr = nullptr;  // not owned: free_buffer becomes a no-op
                                    // for the gpu_ptr; per-rail MRs still freed.
-        s->rails[0].recv_buf_mr = gpu_mr::register_gpu_buffer(
-            s->rails[0].pd, s->recv_buf.gpu_ptr, s->recv_buf.size);
-        for (int r = 1; r < num_rails; r++) {
-            s->rails[r].recv_buf_mr = gpu_mr::register_gpu_buffer(
-                s->rails[r].pd, s->recv_buf.gpu_ptr, s->recv_buf.size);
+        s->recv_buf_aliases_local_data =
+            cfg.external_recv_buf == cfg.local_gpu_buf &&
+            cfg.recv_buf_size == cfg.local_gpu_buf_size;
+        if (s->recv_buf_aliases_local_data) {
+            for (int r = 0; r < num_rails; r++) {
+                s->rails[r].recv_buf_mr = s->rails[r].local_data_mr;
+            }
+        } else {
+            s->rails[0].recv_buf_mr = gpu_mr::register_gpu_buffer(
+                s->rails[0].pd, s->recv_buf.gpu_ptr, s->recv_buf.size);
+            for (int r = 1; r < num_rails; r++) {
+                s->rails[r].recv_buf_mr = gpu_mr::register_gpu_buffer(
+                    s->rails[r].pd, s->recv_buf.gpu_ptr, s->recv_buf.size);
+            }
         }
     } else {
         // Use rail 0 for the allocation + primary MR.
@@ -829,7 +845,8 @@ inline void destroy_session(Session* s) {
         if (s->rails[r].clocal_data_mr) rdma::dereg_mr(s->rails[r].clocal_data_mr);
         // owned mode: rail 0's MR is freed by gpu_mr::free_buffer below.
         // external mode: dereg rail 0 too (free_buffer won't touch it).
-        const bool dereg_recv = external_recv_buf || (r > 0);
+        const bool dereg_recv =
+            !s->recv_buf_aliases_local_data && (external_recv_buf || (r > 0));
         if (dereg_recv && s->rails[r].recv_buf_mr) rdma::dereg_mr(s->rails[r].recv_buf_mr);
     }
     // Clear the pointers that gpu_mr::free_buffer and arrival/barrier teardown

--- a/include/dist/backend_proxy.cuh
+++ b/include/dist/backend_proxy.cuh
@@ -148,10 +148,10 @@ distributed_tensor<GL, LOCAL_SIZE, MULTICAST, NUM_CHANNELS, NUM_NODES, TMA_Types
  * send strategy:
  *
  *   - `SendMode::DmabufDirect` (zero-copy, default): asserts that every rail
- *     has a non-null `clocal_data_mr` — i.e., the session was created with
- *     `direct_dmabuf_enabled=true` and `local_gpu_buf` set to the dbuf's
- *     data. `put_inter` will produce `cmd.src_view=1` (single-SGE direct
- *     read from the local DMA-BUF MR).
+ *     has a non-null `clocal_data_mr` — i.e., the session registered the
+ *     dbuf's data as a direct GPU MR. `put_inter` will produce `cmd.src_view=1`
+ *     (single-SGE direct read from that MR). The historical enum name includes
+ *     "Dmabuf", but the MR can also come from peermem for cudaMalloc buffers.
  *   - `SendMode::Staging`: no MR check; proxy reads from a caller-provided
  *     staging buffer. The kernel must pack data into staging before
  *     `put_inter`. Compatible with kernels that don't have working DMA-BUF.
@@ -176,17 +176,17 @@ __host__ inline void attach_channels_proxy(
     if (session.fifo_bundle.num_fifos <= 0)
         throw std::runtime_error("dist::attach_channels_proxy: empty D2HFifoDeviceBundle");
 
-    // Zero-copy modes require DMA-BUF MR on every rail. Staging mode skips
-    // this check — its proxy reads from a separately-registered buffer.
+    // Zero-copy modes require a direct GPU MR on every rail. Staging mode
+    // skips this check — its proxy reads from a separately-registered buffer.
     if (mode == SendMode::DmabufDirect || mode == SendMode::StridedGather) {
         for (int r = 0; r < session.num_rails; ++r) {
             if (!session.rails[r].clocal_data_mr) {
                 throw std::runtime_error(
                     "dist::attach_channels_proxy: rail " + std::to_string(r) +
-                    " has no clocal_data_mr — zero-copy mode requires session "
-                    "created with direct_dmabuf_enabled=true and local_gpu_buf "
-                    "set to the dbuf's data. Pass SendMode::Staging if your "
-                    "kernel packs into a staging buffer instead.");
+                    " has no clocal_data_mr — zero-copy mode requires the "
+                    "session to register the dbuf's data as a direct GPU MR. "
+                    "Pass SendMode::Staging if your kernel packs into a "
+                    "staging buffer instead.");
             }
         }
     }
@@ -221,7 +221,8 @@ __host__ inline void attach_channels_proxy(
 /**
  * @brief Create an internode session for zero-copy dbuf sends.
  *
- * Requires DMA-BUF registration for the dbuf data buffer. `dbuf.put_inter()`
+ * Requires direct GPU MR registration for the dbuf data buffer. DMA-BUF is
+ * preferred; cudaMalloc-backed buffers can use peermem. `dbuf.put_inter()`
  * sends with `src_view = 1`, so the proxy reads directly from the local MR.
  */
 template<typename DBUF>
@@ -239,9 +240,10 @@ __host__ inline internode::Session* bind_inter_proxy(
                   "bind_inter_proxy requires NUM_CHANNELS > 0");
 
     // Zero-copy modes (DmabufDirect, StridedGather) force the session to
-    // register the dbuf's data buffer as a DMA-BUF MR on every rail. Staging
-    // mode leaves direct_dmabuf_enabled at the caller's setting (typically
-    // false) — the proxy will read from a separately-managed staging buffer.
+    // register the dbuf's data buffer as a direct GPU MR on every rail.
+    // Staging mode leaves direct_dmabuf_enabled at the caller's setting
+    // (typically false) — the proxy will read from a separately-managed
+    // staging buffer.
     if (mode == SendMode::DmabufDirect || mode == SendMode::StridedGather) {
         cfg.direct_dmabuf_enabled = true;
         cfg.local_gpu_buf         = dbuf_data_ptr;
@@ -257,7 +259,7 @@ __host__ inline internode::Session* bind_inter_proxy(
             if (!session->rails[r].clocal_data_mr) {
                 internode::destroy_session(session);
                 throw std::runtime_error(
-                    "bind_inter_proxy: DMA-BUF MR registration failed on rail "
+                    "bind_inter_proxy: direct GPU MR registration failed on rail "
                     + std::to_string(r) + " — zero-copy contract violated");
             }
         }

--- a/include/dist/distributed_buffer.cuh
+++ b/include/dist/distributed_buffer.cuh
@@ -43,7 +43,8 @@ struct alignas(128) TileFlag {
 };
 
 /// Send mode — picks the proxy's WQE construction strategy.
-///   DmabufDirect: src_view=1, zero-copy single-SGE from local DMA-BUF MR.
+///   DmabufDirect: src_view=1, zero-copy single-SGE from direct GPU MR.
+///                 Historical name; MR may be DMA-BUF or peermem-backed.
 ///                 Requires session.rails[*].clocal_data_mr non-null.
 ///   Staging     : src_view=0, proxy reads from a caller-provided staging
 ///                 buffer (the kernel packs into staging before put_inter).
@@ -115,9 +116,8 @@ struct Channel {
     /* ----- Send mode (set at attach/bind time) -----
      * Controls the src_view byte the proxy sees on every put_inter from this
      * channel. Zero-copy modes (DmabufDirect, StridedGather) require the
-     * session to have been created with direct_dmabuf_enabled=true and a
-     * non-null clocal_data_mr per rail; Staging mode tolerates a session
-     * without DMA-BUF support.
+     * session to have a non-null direct GPU clocal_data_mr per rail; Staging
+     * mode tolerates a session without direct GPU source registration.
      */
     SendMode  mode;
 };

--- a/include/dist/parallel_buffer.cuh
+++ b/include/dist/parallel_buffer.cuh
@@ -5,6 +5,7 @@
 #include <map>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <ATen/ops/from_blob.h>
@@ -88,7 +89,8 @@ struct ParallelBuffer {
         const at::ScalarType dtype,
         int local_rank,
         int local_world_size,
-        bool multicast
+        bool multicast,
+        const std::string &backing = "vmm"
     ) : shape_(shape),
         dtype_(dtype),
         raw_ptrs_(local_world_size, nullptr),
@@ -112,12 +114,28 @@ struct ParallelBuffer {
         if (brokers_.size() > 1)
             std::cerr << "WARNING: 2 LocalBroker instances created in the same process. This is not safe." << std::endl;
 
-        c10::cuda::CUDAGuard device_guard(local_rank_);
-        create_shareable_cuda_tensor();
-        exchange_ipc_handles<comm::ipc::Flavor::kVmmFd>();
+        TORCH_CHECK(backing == "vmm" || backing == "cuda_malloc",
+            "Unsupported ParallelBuffer backing '", backing,
+            "'. Expected 'vmm' or 'cuda_malloc'.");
 
-        if (multicast_)
-            initialize_multicast();
+        c10::cuda::CUDAGuard device_guard(local_rank_);
+        if (backing == "vmm") {
+            ipc_flavor_ = comm::ipc::Flavor::kVmmFd;
+            create_shareable_cuda_tensor();
+            exchange_ipc_handles<comm::ipc::Flavor::kVmmFd>();
+
+            if (multicast_)
+                initialize_multicast();
+        } else if (backing == "cuda_malloc") {
+            TORCH_CHECK(!multicast_,
+                "ParallelBuffer backing='cuda_malloc' uses legacy CUDA IPC and "
+                "does not support CUDA multicast. Use backing='vmm' for multicast buffers.");
+            ipc_flavor_ = comm::ipc::Flavor::kLegacy;
+            create_cuda_malloc_tensor();
+            exchange_ipc_handles<comm::ipc::Flavor::kLegacy>();
+        } else {
+            TORCH_CHECK(false, "Unreachable ParallelBuffer backing: ", backing);
+        }
     }
 
     ParallelBuffer(const ParallelBuffer&) = delete;
@@ -136,11 +154,13 @@ struct ParallelBuffer {
         multicast_ptr_(other.multicast_ptr_),
         multicast_allocated_size_(other.multicast_allocated_size_),
         ipc_flavor_(other.ipc_flavor_) {
+        local_vmm_handle_ = std::move(other.local_vmm_handle_);
         other.data_ = at::Tensor();
         other.shape_.clear();
         other.dtype_ = at::ScalarType::Undefined;
         other.raw_ptrs_.clear();
         other.allocated_size_ = 0;
+        other.local_vmm_handle_.reset();
         other.local_rank_ = -1;
         other.local_world_size_ = -1;
         other.multicast_ = false;
@@ -183,8 +203,37 @@ struct ParallelBuffer {
             if (!p) return;
             c10::cuda::CUDAGuard device_guard(local_rank);
             auto stream = c10::cuda::getCurrentCUDAStream().stream();
-            CUDACHECK(cudaStreamSynchronize(stream));
+            MKERNEL_CUDACHECK(cudaStreamSynchronize(stream));
             comm::vmm::unmap(raw_ptr, allocated_size);
+        };
+
+        at::TensorOptions options = at::TensorOptions()
+            .dtype(dtype_)
+            .device(at::kCUDA, local_rank_);
+
+        data_ = at::from_blob(raw_ptr, shape_, std::move(deleter), options);
+    }
+
+    __host__ inline void create_cuda_malloc_tensor() {
+        c10::cuda::CUDAGuard device_guard(local_rank_);
+
+        TORCH_CHECK(!shape_.empty(), "Shape must be non-empty");
+        TORCH_CHECK(shape_.size() <= 4, "Shape must have at most 4 dimensions for ParallelBuffer");
+        size_t size = c10::elementSize(dtype_);
+        for (auto dim : shape_) {
+            TORCH_CHECK(dim > 0, "Size dimensions must be positive");
+            size *= static_cast<size_t>(dim);
+        }
+
+        void *raw_ptr = nullptr;
+        MKERNEL_CUDACHECK(cudaMalloc(&raw_ptr, size));
+        allocated_size_ = size;
+
+        int local_rank = local_rank_;
+        auto deleter = [local_rank](void* p) mutable {
+            if (!p) return;
+            c10::cuda::CUDAGuard device_guard(local_rank);
+            MKERNEL_CUDACHECK(cudaFree(p));
         };
 
         at::TensorOptions options = at::TensorOptions()
@@ -289,6 +338,10 @@ struct ParallelBuffer {
     }
 
     __host__ inline void destroy() {
+        if (local_rank_ < 0 || local_world_size_ <= 0) {
+            return;
+        }
+
         if (multicast_ && multicast_ptr_) {
             brokers_.at({local_rank_, local_world_size_}).sync();
             comm::vmm::Handle multicast_handle;
@@ -342,12 +395,13 @@ struct ParallelBuffer {
              pybind11::arg("local_rank"), \
              pybind11::arg("local_world_size"), \
              pybind11::arg("multicast") = false) \
-        .def(pybind11::init<const std::vector<int64_t>&, const at::ScalarType&, int, int, bool>(), \
+        .def(pybind11::init<const std::vector<int64_t>&, const at::ScalarType&, int, int, bool, const std::string&>(), \
              pybind11::arg("shape"), \
              pybind11::arg("dtype"), \
              pybind11::arg("local_rank"), \
              pybind11::arg("local_world_size"), \
-             pybind11::arg("multicast") = false) \
+             pybind11::arg("multicast") = false, \
+             pybind11::arg("backing") = "vmm") \
         .def("data", &dist::ParallelBuffer::data) \
         .def_readonly("data_", &dist::ParallelBuffer::data_) \
         .def_property_readonly("multicast_ptr_u64", [](const dist::ParallelBuffer &t) { \

--- a/include/operators/ag_gemm/ag_gemm.cuh
+++ b/include/operators/ag_gemm/ag_gemm.cuh
@@ -289,10 +289,11 @@ __device__ inline void post_merge_wrs_for_intra_row(
     }
 }
 
-// Forward a fully published A row-block from A_recv (registered as local_data_mr
-// in ring mode) to the next node. `source_slot` is the physical peer slot in
-// this node's A_recv multicast buffer that contains `origin_rank`'s shard.
-// `dst_bank` selects the destination bank on the next rank (1..n_peers-1).
+// Forward a fully received A row-block to the next node. `source_slot` is the
+// physical peer slot for `origin_rank` on this node; `dst_bank` selects the
+// destination recv bank on the next rank (1..n_peers-1). The matching source
+// bank is `dst_bank - 1`: step 0 forwards from bank 0 into peer bank 1, step 1
+// forwards from bank 1 into peer bank 2, and so on.
 __device__ inline void post_ring_forward_wrs_for_intra_row(
     const globals& G, int source_slot, int origin_rank,
     int global_row_idx, int chunks_per_rb, int dst_bank) {
@@ -301,8 +302,10 @@ __device__ inline void post_ring_forward_wrs_for_intra_row(
     const int dst_slot = internode::slot_at_peer(origin_rank, next_rank, G.num_nodes);
     const int n_peers = G.num_nodes - 1;
     const int dst_virtual = dst_slot + n_peers * dst_bank;
+    const int src_bank = max(0, dst_bank - 1);
+    const int src_virtual = source_slot + n_peers * src_bank;
     const uint64_t src_slot_base =
-        (uint64_t)source_slot * (uint64_t)G.a_half_bytes;
+        (uint64_t)src_virtual * (uint64_t)G.a_half_bytes;
     const uint64_t dst_slot_base =
         (uint64_t)dst_virtual * (uint64_t)G.a_half_bytes;
 #pragma unroll

--- a/include/operators/dispatch_gemm/session.cuh
+++ b/include/operators/dispatch_gemm/session.cuh
@@ -30,9 +30,9 @@ void create_session_py(int rank, const std::string& peer_ip, int tcp_port,
     internode::py::apply_peer_ips(
         cfg, peer_ips, peer_tcp_ports, tcp_port,
         g_peer_ips_storage, g_peer_ips_cstr, g_peer_ports_storage);
-    // Zero-copy send: register pre_tokens (DistBuffer, VMM) as the
-    // session's only data MR via register_gpu_buffer(), which transparently
-    // uses cuMemGetHandleForAddressRange + ibv_reg_dmabuf_mr on VMM ranges.
+    // Zero-copy send: register pre_tokens as the session's data MR via
+    // register_gpu_buffer(). VMM buffers use DMA-BUF when supported;
+    // cudaMalloc-backed buffers can fall back to peermem/ibv_reg_mr.
     // The kernel emits cmd.src_view=0; only the source address changes.
     // send_buf_ptr/size are kept in the signature for compatibility but unused.
     if (pre_tokens_buf_ptr == 0 || pre_tokens_buf_size == 0) {

--- a/include/operators/gemm_rs/session.cuh
+++ b/include/operators/gemm_rs/session.cuh
@@ -32,10 +32,8 @@ void create_session_py(int rank, const std::string& peer_ip, int tcp_port,
         cfg, peer_ips, peer_tcp_ports, tcp_port,
         g_peer_ips_storage, g_peer_ips_cstr, g_peer_ports_storage);
 
-    // GEMM_RS_DIRECT_DMABUF_SEND: register output_local as a DMA-BUF MR on every
-    // rail's PD so the send path can skip the pack + gather step. Session
-    // creation hard-fails if the buffer can't be DMA-BUF-exported (no peermem
-    // fallback — we want the direct path or nothing).
+    // Direct GPU-send sessions register their source buffer through the common
+    // GPU-MR path: DMA-BUF first, then peermem for cudaMalloc-backed buffers.
     cfg.max_inflight = 256;
     // Default to 4 QPs per endpoint; multi-NIC striping is controlled by the
     // internode session configuration.

--- a/include/operators/ring_attention/ring_attention.cuh
+++ b/include/operators/ring_attention/ring_attention.cuh
@@ -51,7 +51,6 @@
 
 #include <ATen/ATen.h>
 #include <c10/cuda/CUDAGuard.h>
-#include <cstdlib>
 #include <cstdio>
 #include <vector>
 #include <algorithm>
@@ -151,9 +150,9 @@ struct globals {
 // copied peer KV around the local M-GPU ring just like the round-0 local KV.
 
 struct kv_exchange_globals {
-    bf16 *send_buf;          // legacy staging buffer pointer, unused under
+    bf16 *send_buf;          // staging buffer pointer, unused under
                              // zero-copy send (K0/V0 are RDMA-registered
-                             // directly via DMA-BUF; src_view selects between
+                             // directly; src_view selects between
                              // them at the proxy).
     // Base pointer to the receive buffer. At N peers the buffer is laid out
     // as (N-1) consecutive [K | V] slots; the kv_copy kernel takes a peer
@@ -170,6 +169,7 @@ struct kv_exchange_globals {
     int   num_nodes;  // total node count (>= 2).
     int   num_send_sms;
     int   num_copy_sms;
+    int   use_staging_source;
 
     internode::D2HFifoDeviceBundle d2h_fifos;
     volatile uint32_t *arrival_flags;
@@ -247,7 +247,8 @@ inline void entrypoint(
     int num_comm_sms,
     int num_send_sms,
     int num_copy_sms,
-    int num_nodes
+    int num_nodes,
+    bool staging_source
 ) {
     const int dev_idx = barrier.local_rank_;
     c10::cuda::CUDAGuard device_guard(dev_idx);
@@ -298,6 +299,7 @@ inline void entrypoint(
         .num_nodes = num_nodes,
         .num_send_sms = n_send,
         .num_copy_sms = n_copy,
+        .use_staging_source = staging_source ? 1 : 0,
         .d2h_fifos = fifo_bundle,
         .arrival_flags = reinterpret_cast<volatile uint32_t*>(arrival_flags_ptr),
         .epoch = (uint32_t)epoch,

--- a/include/operators/ring_attention/session.cuh
+++ b/include/operators/ring_attention/session.cuh
@@ -6,6 +6,7 @@
 // Session management + pybind module
 // ============================================================================
 #include "comm/internode/session_py.cuh"
+#include <cstdlib>
 #include <cuda_runtime.h>
 #include <torch/csrc/utils/pybind.h>
 
@@ -22,6 +23,7 @@ void create_session_py(int rank, const std::string& peer_ip, int tcp_port,
                        int64_t k0_buf_size,
                        int64_t v0_buf_ptr,
                        int64_t v0_buf_size,
+                       bool staging_source,
                        std::vector<std::string> peer_ips = {},
                        std::vector<int> peer_tcp_ports = {}) {
     internode::py::destroy_session(g_session);
@@ -32,20 +34,30 @@ void create_session_py(int rank, const std::string& peer_ip, int tcp_port,
     internode::py::apply_peer_ips(
         cfg, peer_ips, peer_tcp_ports, tcp_port,
         g_peer_ips_storage, g_peer_ips_cstr, g_peer_ports_storage);
-    // Zero-copy send: K0 (src_view=0) and V0 (src_view=1) registered as
-    // DMA-BUF MRs. Proxy posts single-SGE WRs straight from the VMM tensors
-    // — no pack copy. send_buf_ptr/size are kept in the signature for
-    // backwards compatibility but unused.
-    if (k0_buf_ptr == 0 || v0_buf_ptr == 0) {
+    // Default zero-copy send: K0 (src_view=0) and V0 (src_view=1) are direct
+    // GPU MRs. Peermem-compatible mode keeps K/V as VMM ring buffers and sends
+    // from a cudaMalloc staging buffer instead, because the intra-node TMA ring
+    // relies on the VMM/IPC peer views.
+    if (!staging_source && (k0_buf_ptr == 0 || v0_buf_ptr == 0)) {
         fprintf(stderr, "create_session_py: ring_attention zero-copy send requires k0/v0 ptrs\n");
         std::exit(EXIT_FAILURE);
     }
-    (void)send_buf_ptr; (void)send_buf_size;
-    cfg.local_gpu_buf = reinterpret_cast<void*>(k0_buf_ptr);
-    cfg.local_gpu_buf_size = (size_t)k0_buf_size;
-    cfg.clocal_gpu_buf = reinterpret_cast<void*>(v0_buf_ptr);
-    cfg.clocal_gpu_buf_size = (size_t)v0_buf_size;
-    cfg.direct_dmabuf_enabled = true;
+    if (staging_source) {
+        if (send_buf_ptr == 0 || send_buf_size == 0) {
+            fprintf(stderr, "create_session_py: ring_attention staging source requires send_buf ptr+size\n");
+            std::exit(EXIT_FAILURE);
+        }
+        cfg.local_gpu_buf = reinterpret_cast<void*>(send_buf_ptr);
+        cfg.local_gpu_buf_size = (size_t)send_buf_size;
+        cfg.direct_dmabuf_enabled = false;
+    } else {
+        (void)send_buf_ptr; (void)send_buf_size;
+        cfg.local_gpu_buf = reinterpret_cast<void*>(k0_buf_ptr);
+        cfg.local_gpu_buf_size = (size_t)k0_buf_size;
+        cfg.clocal_gpu_buf = reinterpret_cast<void*>(v0_buf_ptr);
+        cfg.clocal_gpu_buf_size = (size_t)v0_buf_size;
+        cfg.direct_dmabuf_enabled = true;
+    }
     cfg.max_inflight = 32;
     if (const char* env_mi = std::getenv("MKERNEL_MAX_INFLIGHT")) {
         cfg.max_inflight = std::atoi(env_mi);
@@ -81,6 +93,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
           pybind11::arg("fifo_capacity"), pybind11::arg("device_id"),
           pybind11::arg("k0_buf_ptr"), pybind11::arg("k0_buf_size"),
           pybind11::arg("v0_buf_ptr"), pybind11::arg("v0_buf_size"),
+          pybind11::arg("staging_source"),
           pybind11::arg("peer_ips") = std::vector<std::string>{},
           pybind11::arg("peer_tcp_ports") = std::vector<int>{});
     m.def("destroy_session", &destroy_session_py);
@@ -112,5 +125,6 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
           pybind11::arg("num_comm_sms"),
           pybind11::arg("num_send_sms"),
           pybind11::arg("num_copy_sms"),
-          pybind11::arg("num_nodes"));
+          pybind11::arg("num_nodes"),
+          pybind11::arg("staging_source"));
 }

--- a/plots/plot_tflops_efa.py
+++ b/plots/plot_tflops_efa.py
@@ -259,7 +259,7 @@ def load_series(kernel: str):
     """Returns (shapes, fused_tf, nccl_tf, cx7_tf or None)."""
     fused = json.load(open(RESULTS / f"{kernel}_efa.json"))
     nccl = json.load(open(RESULTS / f"{kernel}_nccl.json"))
-    cx7 = json.load(open(CX7_PATH))
+    cx7 = json.load(open(CX7_PATH)) if CX7_PATH.exists() else {}
 
     shapes = [_parse_shape(s) for s in fused["sizes"]]
     # ring_attention release JSON stores per-rank seq_per_dev; align to
@@ -274,6 +274,8 @@ def load_series(kernel: str):
     # NCCL JSON may have nccl_ms keyed differently
     nccl_ms = nccl.get("nccl_ms", nccl.get("fused_ms", []))
     nccl_shapes = [_parse_shape(s) for s in nccl["sizes"]]
+    if kernel == "ring_attention":
+        nccl_shapes = [s * WORLD for s in nccl_shapes]
     # Align NCCL shapes to fused shapes
     nccl_by_shape = {sh: ms for sh, ms in zip(nccl_shapes, nccl_ms)}
     nccl_tf = [KERNELS[kernel]["tflops_fn"](s, nccl_by_shape.get(s))

--- a/src/ring_attention.cu
+++ b/src/ring_attention.cu
@@ -433,10 +433,10 @@ __device__ inline void attn_comm(const globals &G, const int block_idx, const in
 // ============================================================================
 //
 // Zero-copy KV send: skips the K0/V0 → send_buf pack. K0 is registered as
-// the session's local_gpu_buf (src_view=0), V0 as clocal_gpu_buf (src_view=1),
-// both via DMA-BUF (`direct_dmabuf_enabled=true`). The proxy posts a single-SGE
-// RDMA write straight from the registered VMM tensor, so no GPU-memory copy
-// is required on the sender side.
+// the session's local_gpu_buf (src_view=0), V0 as clocal_gpu_buf (src_view=1).
+// The MR may be DMA-BUF-backed for VMM or peermem-backed for cudaMalloc. The
+// proxy posts a single-SGE RDMA write straight from the registered tensor, so
+// no GPU-memory copy is required on the sender side.
 //
 // Layout invariants:
 //   - K0/V0 are row-major contiguous DistBuffers of size K_bytes/V_bytes.
@@ -658,7 +658,11 @@ void kv_send_kernel(
     const __grid_constant__ kv_exchange_globals KE
 ) {
     if ((int)blockIdx.x < KE.num_send_sms) {
-        kv_stage_and_send_sm(KE);
+        if (KE.use_staging_source != 0) {
+            kv_send_sm(KE);
+        } else {
+            kv_stage_and_send_sm(KE);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Add a `MKERNEL_RDMA_BUFFER_BACKING=peermem` mode for RoCE systems where GPU RDMA registration works through `cudaMalloc` + `nvidia_peermem` rather than VMM DMA-BUF.
- Route the backing policy through AG_GEMM, GEMM_RS, dispatch_gemm, ring_attention, and `ParallelBuffer`, while keeping the existing VMM DMA-BUF path as the default.


