### PR TITLE
ag_gemm bench: restore num_comm_sms for shapes absent from SMS_PER_SHAPE

### DIFF
--- a/bench/ag_gemm_bench.py
+++ b/bench/ag_gemm_bench.py
@@ -95,6 +95,7 @@ def main():
     # Preserve explicit --num-intra-comm-sms from the CLI (e.g. AG_GEMM_BENCH_EXTRA
     # profile runs). The per-shape loop used to force 0 here, which silently ignored
     # tuned intra splits unless INTRA_OVERRIDE was populated.
+    cli_num_comm_sms = int(args.num_comm_sms)
     cli_num_intra_comm_sms = int(args.num_intra_comm_sms)
     rank = int(os.environ["RANK"])
     local_rank = int(os.environ["LOCAL_RANK"])
@@ -149,6 +150,8 @@ def main():
             if is_chief:
                 print(f"[ag_gemm] M={base_n}: per-shape num_comm_sms={args.num_comm_sms}",
                       flush=True)
+        else:
+            args.num_comm_sms = cli_num_comm_sms
         if base_n in INTRA_OVERRIDE:
             args.num_intra_comm_sms = INTRA_OVERRIDE[base_n]
             if is_chief:


### PR DESCRIPTION
The per-shape override assigns into args inside the shape loop and never restores it, so any shape not in SMS_PER_SHAPE silently inherits whatever the previous shape set rather than the CLI value. Sweeping 4096,8192,16384,32768 leaves 32768 running with 8 comm CTAs instead of the 64 default, because 32768 is not in the table and 16384 is.

The adjacent INTRA_OVERRIDE block already guards against exactly this with an else that restores cli_num_intra_comm_sms - added, per the comment above it, after the same class of bug was found there. This mirrors that.

Measured impact where it could be measured: at M=32768 the shape runs 8.596 ms on its own and 10.636 ms when preceded by another shape in the same sweep, so any multi-shape number for a table-absent shape is off by about 24%.