### PR TITLE
[AG-GEMM] Ag gemm warp specialized improvements

### DIFF
--- a/bench/ag_gemm_bench.py
+++ b/bench/ag_gemm_bench.py
@@ -510,13 +510,7 @@ def unpad_rows(
     logical_n: int,
 ) -> torch.Tensor:
     """Return the logical [M, logical_n] block of a row/column padded C.
-
-    Each rank contributes padded_local_m rows to the all-gathered output but
-    only the first local_m of them carry real data, so the padding rows sit
-    between rank shards rather than after the last one.
     """
-    if padded_local_m == local_m:
-        return c[:, :logical_n]
     rows = c.view(world_size, padded_local_m, -1)[:, :local_m, :logical_n]
     return rows.reshape(world_size * local_m, logical_n)
 

--- a/bench/ag_gemm_bench.py
+++ b/bench/ag_gemm_bench.py
@@ -16,7 +16,11 @@ E.g. THUNDERKITTENS_PATH=/home/ThunderKittens CUTLASS_PATH=/home/cutlass python 
 """
 from __future__ import annotations
 
-import argparse, json, os, sys, time
+import argparse
+import json
+import os
+import sys
+import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from itertools import product
@@ -38,6 +42,7 @@ from common import (  # noqa: E402
     check_deterministic_rerun,
     compare_named_results,
     gather_cpu_tensors,
+    get_num_nodes,  # noqa: E402
     get_peer_ips,
     get_peer_ports,
     is_peermem_backing,
@@ -46,7 +51,6 @@ from common import (  # noqa: E402
     rdma_policy_label,
 )
 
-from common import get_num_nodes  # noqa: E402
 
 class HopperBenchConfig:
     arch = "hopper"
@@ -126,25 +130,7 @@ class BlackwellBenchConfig:
     )
     shapes_to_test = [2048, 3072, 3584, 4096, 8192, 16384, 32768]
     default_k = 7168
-    
-    # mkernel configs
-    mkernel_per_shape_config = {  # noqa: RUF012
-        # (projection, logical global M): (COL_BLOCK, NUM_CTA)
-        ("KDA", 2048): (128, 2),
-        ("KDA", 3072): (256, 2),
-        ("KDA", 3584): (256, 2),
-        ("KDA", 4096): (256, 2),
-        ("KDA", 8192): (256, 2),
-        ("KDA", 16384): (256, 2),
-        ("KDA", 32768): (256, 2),
-        ("MLA", 2048): (128, 2),
-        ("MLA", 3072): (128, 1),
-        ("MLA", 3584): (256, 2),
-        ("MLA", 4096): (256, 2),
-        ("MLA", 8192): (256, 2),
-        ("MLA", 16384): (256, 2),
-        ("MLA", 32768): (256, 2),
-    }
+
     # cutlass configs
     cutlass_autotune_configs = (
         ((256, 128), (2, 1), True),
@@ -541,10 +527,9 @@ def check_correctness_ag_gemm_blackwell(config: BlackwellBenchConfig, mod):
             raise ValueError(f"global M={m} is not divisible by {config.world_size=}")
 
         local_m = m // config.world_size
-        col_block, num_cta = config.mkernel_per_shape_config[(projection, m)]
-        padded_local_m = round_up(local_m, 128 * num_cta)
+        padded_local_m = round_up(local_m, 16)
         padded_m = padded_local_m * config.world_size
-        padded_n = round_up(logical_n, col_block)
+        padded_n = round_up(logical_n, 16)
 
         torch.manual_seed(42 + config.local_rank)
         torch.cuda.manual_seed(42 + config.local_rank)
@@ -574,13 +559,13 @@ def check_correctness_ag_gemm_blackwell(config: BlackwellBenchConfig, mod):
         )
         A_kernel.data_.copy_(pad_rows(config, A_ref_local, padded_local_m))
         A_local_buf = torch.empty(
-            (padded_m, config.default_k), device="cuda", dtype=torch.bfloat16
+            (config.world_size, padded_local_m, config.default_k), device="cuda", dtype=torch.bfloat16
         )
         # ag_gemm_warp_specialized takes B pre-transposed to [N, K] (contiguous K reads
         # per N-tile); see the same transform in ag_gemm_blackwell_prepare.
         B_kernel = pad_cols(config, B_ref, padded_n).T.contiguous()
         C_kernel = torch.zeros(
-            (padded_m, padded_n), device="cuda", dtype=torch.bfloat16
+            (config.world_size, padded_local_m, padded_n), device="cuda", dtype=torch.bfloat16
         )
 
         # The kernel's first act is to pull every peer's shard out of their
@@ -806,10 +791,9 @@ def ag_gemm_blackwell_prepare(
     fns.append((bench_baseline, "baseline", True))
 
     # ---- mkernel: ag_gemm_warp_specialized dispatch ----
-    col_block, num_cta = config.mkernel_per_shape_config[(projection, global_m)]
-    mk_local_m = round_up(run_config.logical_m, 128 * num_cta)
+    mk_local_m = round_up(run_config.logical_m, 16)
     mk_m = mk_local_m * config.world_size
-    mk_n = round_up(run_config.logical_n, col_block)
+    mk_n = round_up(run_config.logical_n, 16)
     run_config.mkernel_padded_m = mk_m
     run_config.mkernel_padded_n = mk_n
 
@@ -824,9 +808,9 @@ def ag_gemm_blackwell_prepare(
     )
     run_config.mkernel_a_dist.data_.copy_(A_mk_local)
     run_config.mkernel_a_local_buf = torch.empty(
-        (mk_m, config.default_k), device="cuda", dtype=torch.bfloat16
+        (config.world_size, mk_local_m, config.default_k), device="cuda", dtype=torch.bfloat16
     )
-    run_config.mkernel_c_buf = torch.zeros((mk_m, mk_n), device="cuda", dtype=torch.bfloat16)
+    run_config.mkernel_c_buf = torch.zeros((config.world_size, mk_local_m, mk_n), device="cuda", dtype=torch.bfloat16)
 
     # The kernel's first act is to pull every peer's shard out of their
     # DistBuffer, so no rank may launch until all of them have finished

--- a/bench/ag_gemm_bench.py
+++ b/bench/ag_gemm_bench.py
@@ -16,11 +16,7 @@ E.g. THUNDERKITTENS_PATH=/home/ThunderKittens CUTLASS_PATH=/home/cutlass python 
 """
 from __future__ import annotations
 
-import argparse
-import json
-import os
-import sys
-import time
+import argparse, json, os, sys, time
 from collections.abc import Callable
 from dataclasses import dataclass
 from itertools import product
@@ -42,7 +38,6 @@ from common import (  # noqa: E402
     check_deterministic_rerun,
     compare_named_results,
     gather_cpu_tensors,
-    get_num_nodes,  # noqa: E402
     get_peer_ips,
     get_peer_ports,
     is_peermem_backing,
@@ -51,6 +46,7 @@ from common import (  # noqa: E402
     rdma_policy_label,
 )
 
+from common import get_num_nodes  # noqa: E402
 
 class HopperBenchConfig:
     arch = "hopper"

--- a/include/operators/ag_gemm/ag_gemm_warp_specialized.cuh
+++ b/include/operators/ag_gemm/ag_gemm_warp_specialized.cuh
@@ -314,10 +314,10 @@ void entrypoint(dist::ParallelBuffer& A,
                 break;
             }
             case 32768: {
-                using fg = fused_globals<128, 256, 2, 1>;
+                using fg = fused_globals<128, 256, 2>;
                 fg globals =
-                    ag_gemm_warp_specialized_make_globals<128, 256, 2, 1>(A, A_local_buf, B, C, dev_idx, M, N);
-                launch_ag_gemm_warp_specialized<128, 256, 2, 15, 1>(globals);
+                    ag_gemm_warp_specialized_make_globals<128, 256, 2>(A, A_local_buf, B, C, dev_idx, M, N);
+                launch_ag_gemm_warp_specialized<128, 256, 2, 15>(globals);
                 break;
             }
             default:

--- a/include/operators/ag_gemm/ag_gemm_warp_specialized.cuh
+++ b/include/operators/ag_gemm/ag_gemm_warp_specialized.cuh
@@ -242,10 +242,10 @@ void entrypoint(dist::ParallelBuffer& A,
                 break;
             }
             case 8192: {
-                using fg = fused_globals<128, 256, 2>;
-                fg globals = ag_gemm_warp_specialized_make_globals<128, 256, 2>(
+                using fg = fused_globals<128, 256, 2, 2>;
+                fg globals = ag_gemm_warp_specialized_make_globals<128, 256, 2, 2>(
                     A, A_local_buf, B, C, dev_idx, M, N);
-                launch_ag_gemm_warp_specialized<128, 256, 2, 20>(globals);
+                launch_ag_gemm_warp_specialized<128, 256, 2, 5, 2>(globals);
                 break;
             }
             case 16384: {
@@ -263,7 +263,7 @@ void entrypoint(dist::ParallelBuffer& A,
                 using fg = fused_globals<128, 256, 2, 2>;
                 fg globals = ag_gemm_warp_specialized_make_globals<128, 256, 2, 2>(
                     A, A_local_buf, B, C, dev_idx, M, N);
-                launch_ag_gemm_warp_specialized<128, 256, 2, 10, 2>(globals);
+                launch_ag_gemm_warp_specialized<128, 256, 2, 5, 2>(globals);
                 break;
             }
             default:
@@ -314,12 +314,10 @@ void entrypoint(dist::ParallelBuffer& A,
                 break;
             }
             case 32768: {
-                // 2-consumer-warp, 2-CTA path: MLA at this shape divides
-                // evenly across NUM_CLUSTERS * NUM_CONSUMER_WARPS.
-                using fg = fused_globals<128, 256, 2, 2>;
-                fg globals = ag_gemm_warp_specialized_make_globals<128, 256, 2, 2>(
+                using fg = fused_globals<128, 256, 2, 1>;
+                fg globals = ag_gemm_warp_specialized_make_globals<128, 256, 2, 1>(
                     A, A_local_buf, B, C, dev_idx, M, N);
-                launch_ag_gemm_warp_specialized<128, 256, 2, 20, 2>(globals);
+                launch_ag_gemm_warp_specialized<128, 256, 2, 15, 1>(globals);
                 break;
             }
             default:

--- a/include/operators/ag_gemm/ag_gemm_warp_specialized.cuh
+++ b/include/operators/ag_gemm/ag_gemm_warp_specialized.cuh
@@ -116,11 +116,15 @@ struct fused_globals {
 
     using A_local_tensor = dist::local_tensor<comm::bf16, 1, 1, -1, -1, A_tile>;
     using A_distributed_tensor = dist::distributed_tensor<A_local_tensor, NUM_DEVICES, true>;
+
+    // we declare a separate A tensor here that is indexed as ((NUM_DEVICES, local_m), K), so that
+    // TMA loads that go out of bounds will naturally zero themselves out
+    using A_replicated_tensor = dist::local_tensor<comm::bf16, 1, NUM_DEVICES, -1, -1, A_tile>;
     using B_local_tensor = dist::local_tensor<comm::bf16, 1, 1, -1, -1, B_tile>;
-    using C_local_tensor = dist::local_tensor<comm::bf16, 1, 1, -1, -1, C_tile>;
+    using C_local_tensor = dist::local_tensor<comm::bf16, 1, NUM_DEVICES, -1, -1, C_tile>;
 
     A_distributed_tensor A;
-    A_local_tensor A_local_buf;
+    A_replicated_tensor A_local_buf;
     B_local_tensor B;
     C_local_tensor C;
 
@@ -174,16 +178,16 @@ ag_gemm_warp_specialized_make_globals(dist::ParallelBuffer& A,
                                       int N) {
     using fg = fused_globals<_ROW_BLOCK, _COL_BLOCK, _NUM_CTA, _NUM_CONSUMER_WARPS>;
 
-    return {
-        .A = ::dist::distributed_tensor_from_buffer<typename fg::A_distributed_tensor>(A),
-        .A_local_buf = ::dist::local_tensor_from_tensor<typename fg::A_local_tensor>(A_local_buf),
-        .B = ::dist::local_tensor_from_tensor<typename fg::B_local_tensor>(B),
-        .C = ::dist::local_tensor_from_tensor<typename fg::C_local_tensor>(C),
-        .A_copy_ready = nullptr,
-        .A_copy_epoch = 0,
-        .dev_idx = dev_idx,
-        .M = M,
-        .N = N};
+    return {.A = ::dist::distributed_tensor_from_buffer<typename fg::A_distributed_tensor>(A),
+            .A_local_buf =
+                ::dist::local_tensor_from_tensor<typename fg::A_replicated_tensor>(A_local_buf),
+            .B = ::dist::local_tensor_from_tensor<typename fg::B_local_tensor>(B),
+            .C = ::dist::local_tensor_from_tensor<typename fg::C_local_tensor>(C),
+            .A_copy_ready = nullptr,
+            .A_copy_epoch = 0,
+            .dev_idx = dev_idx,
+            .M = M,
+            .N = N};
 }
 
 void entrypoint(dist::ParallelBuffer& A,
@@ -196,7 +200,8 @@ void entrypoint(dist::ParallelBuffer& A,
     const int dev_idx = A.local_rank_;
     c10::cuda::CUDAGuard device_guard(dev_idx);
 
-    const int M = C.size(0), N = B.size(0);
+    // C is now [NUM_DEVICES, local_m, N];
+    const int M = C.size(0) * C.size(1), N = B.size(0);
     constexpr int K = fused_globals<128, 128>::K;
 
     TORCH_CHECK(A.local_world_size_ == INTRA_NUM_DEVICES,

--- a/include/operators/ag_gemm/ag_gemm_warp_specialized.cuh
+++ b/include/operators/ag_gemm/ag_gemm_warp_specialized.cuh
@@ -30,8 +30,12 @@ namespace ag_gemm_warp_specialized {
 // CTAs per cluster, i.e. the tcgen05 MMA CTA group. 2 splits COL_BLOCK across
 // the pair so each CTA stages half the B tile; 1 gives every CTA its own MMA.
 static constexpr int DEFAULT_NUM_CTA = 2;
+static constexpr int DEFAULT_NUM_CONSUMER_WARPS = 1;
 
-template <int _ROW_BLOCK, int _COL_BLOCK, int _NUM_CTA = DEFAULT_NUM_CTA>
+template <int _ROW_BLOCK,
+          int _COL_BLOCK,
+          int _NUM_CTA = DEFAULT_NUM_CTA,
+          int _NUM_CONSUMER_WARPS = DEFAULT_NUM_CONSUMER_WARPS>
 struct fused_globals;
 
 // Number of tile columns visited before the snake pattern steps to the next
@@ -41,21 +45,20 @@ static constexpr int DEFAULT_SUPERGROUP_WIDTH = 5;
 template <int _ROW_BLOCK,
           int _COL_BLOCK,
           int _NUM_CTA = DEFAULT_NUM_CTA,
-          int SUPERGROUP_WIDTH = DEFAULT_SUPERGROUP_WIDTH>
-void launch_ag_gemm_warp_specialized(const fused_globals<_ROW_BLOCK, _COL_BLOCK, _NUM_CTA>& G);
-
-static constexpr int DEFAULT_ROW_BLOCK = 128;
-static constexpr int DEFAULT_COL_BLOCK = 128;
+          int SUPERGROUP_WIDTH = DEFAULT_SUPERGROUP_WIDTH,
+          int _NUM_CONSUMER_WARPS = DEFAULT_NUM_CONSUMER_WARPS>
+void launch_ag_gemm_warp_specialized(
+    const fused_globals<_ROW_BLOCK, _COL_BLOCK, _NUM_CTA, _NUM_CONSUMER_WARPS>& G);
 
 // for M < 512, this should be 128
-template <int _ROW_BLOCK, int _COL_BLOCK, int _NUM_CTA>
+template <int _ROW_BLOCK, int _COL_BLOCK, int _NUM_CTA, int _NUM_CONSUMER_WARPS>
 struct fused_globals {
     // config items
     static constexpr int NUM_DEVICES = INTRA_NUM_DEVICES;
 
     // not sure if I want to use a warp specialized or sm specialized strategy yet
     static constexpr int NUM_BLOCKS = 148;
-    static constexpr int CONSUMER_WARPS = 1;
+    static constexpr int CONSUMER_WARPS = _NUM_CONSUMER_WARPS;
     static constexpr int PRODUCER_WARPS = 1;
     static constexpr int EPILOGUE_WARPGROUPS = 1;
     static constexpr int EPILOGUE_WARPS = EPILOGUE_WARPGROUPS * kittens::WARPGROUP_WARPS;
@@ -70,14 +73,18 @@ struct fused_globals {
 
     // this is pipelining along the reduction dimension
     static constexpr int PRODUCER_CONSUMER_PIPELINE_STAGES = []() {
-        if constexpr (_NUM_CTA == 1 || _COL_BLOCK == 256) {
+        if constexpr (_NUM_CONSUMER_WARPS == 2) {
+            return 4;
+        } else if constexpr (_NUM_CTA == 1 || _COL_BLOCK == 256) {
             return 6;
         } else {
             return 7;
         }
     }();
     // this is pipelining among different MMAs
-    static constexpr int TMEM_PIPELINE_STAGES = kittens::MAX_TENSOR_COLS / _COL_BLOCK;
+    static constexpr int TMEM_PIPELINE_STAGES =
+        kittens::MAX_TENSOR_COLS / _COL_BLOCK / CONSUMER_WARPS;
+    static constexpr int NUM_TMEM_SLOTS = TMEM_PIPELINE_STAGES * CONSUMER_WARPS;
     // this is the number of epilogue stages that can be in flight at any time
     static constexpr int EPILOGUE_PIPELINE_STAGES = _COL_BLOCK == 128 ? 3 : 2;
     // this is the number of partitions for the epilogue tile in SMEM
@@ -100,7 +107,7 @@ struct fused_globals {
 
     static constexpr int MAX_DYNAMIC_SHARED_MEMORY = 227 * 1024;
     static constexpr int DYNAMIC_SHARED_MEMORY =
-        (sizeof(A_tile) + sizeof(B_tile)) * PRODUCER_CONSUMER_PIPELINE_STAGES +
+        (sizeof(A_tile) * CONSUMER_WARPS + sizeof(B_tile)) * PRODUCER_CONSUMER_PIPELINE_STAGES +
         sizeof(C_tile) * EPILOGUE_PIPELINE_STAGES + 1024;
     // Deliberately not a static_assert: the tuner instantiates fused_globals
     // for every candidate so it can ask which ones fit. The hard check lives
@@ -128,7 +135,7 @@ struct fused_globals {
     static constexpr int K = 7168;
 
     struct pipeline_inputs {
-        A_tile A;
+        A_tile A[_NUM_CONSUMER_WARPS];
         B_tile B;
     };
 
@@ -139,27 +146,33 @@ struct fused_globals {
     /*
      * bit 0: TMA producer -- starts with 1 (PRODUCER WARP)
      * bit 1: TMA consumer -- starts with 0 (CONSUMER WARP)
-     * bit 2: TMEM producer -- starts with 1 (CONSUMER WARP)
-     * bit 3: TMEM consumer -- starts with 0 (EPILOGUE WARP)
+     * bits [2, 2+CONSUMER_WARPS): TMEM producer, one per consumer warp --
+     *   starts with 1 (CONSUMER WARP), since there is no prior epilogue
+     *   readout for the first pipeline fill to wait on
+     * bits [2+CONSUMER_WARPS, 2+2*CONSUMER_WARPS): TMEM consumer, one per
+     *   consumer warp -- starts with 0 (EPILOGUE WARP)
      */
     static constexpr int TMA_PRODUCER_BIT = 0b1;
-    static constexpr int TMA_CONSUMER_BIT = 0b00;
-    static constexpr int TMEM_PROUCER_BIT = 0b100;
-    static constexpr int TMEM_CONSUMER_BIT = 0b0000;
+    static constexpr int TMA_CONSUMER_BITS = 0b000;
+    static constexpr int TMEM_PRODUCER_BITS = ((1 << CONSUMER_WARPS) - 1) << 2;
+    static constexpr int TMEM_CONSUMER_BITS = 0;
     static constexpr int PHASE_BITS_INIT =
-        TMA_PRODUCER_BIT | TMA_CONSUMER_BIT | TMEM_PROUCER_BIT | TMEM_CONSUMER_BIT;
+        TMA_PRODUCER_BIT | TMA_CONSUMER_BITS | TMEM_PRODUCER_BITS | TMEM_CONSUMER_BITS;
 };
 
-template <int _ROW_BLOCK, int _COL_BLOCK, int _NUM_CTA = DEFAULT_NUM_CTA>
-__host__ inline fused_globals<_ROW_BLOCK, _COL_BLOCK, _NUM_CTA> ag_gemm_warp_specialized_make_globals(
-    dist::ParallelBuffer& A,
-    const at::Tensor& A_local_buf,
-    const at::Tensor& B,
-    at::Tensor& C,
-    int dev_idx,
-    int M,
-    int N) {
-    using fg = fused_globals<_ROW_BLOCK, _COL_BLOCK, _NUM_CTA>;
+template <int _ROW_BLOCK,
+          int _COL_BLOCK,
+          int _NUM_CTA = DEFAULT_NUM_CTA,
+          int _NUM_CONSUMER_WARPS = DEFAULT_NUM_CONSUMER_WARPS>
+__host__ inline fused_globals<_ROW_BLOCK, _COL_BLOCK, _NUM_CTA, _NUM_CONSUMER_WARPS>
+ag_gemm_warp_specialized_make_globals(dist::ParallelBuffer& A,
+                                      const at::Tensor& A_local_buf,
+                                      const at::Tensor& B,
+                                      at::Tensor& C,
+                                      int dev_idx,
+                                      int M,
+                                      int N) {
+    using fg = fused_globals<_ROW_BLOCK, _COL_BLOCK, _NUM_CTA, _NUM_CONSUMER_WARPS>;
 
     return {
         .A = ::dist::distributed_tensor_from_buffer<typename fg::A_distributed_tensor>(A),
@@ -197,51 +210,55 @@ void entrypoint(dist::ParallelBuffer& A,
         switch (logical_global_m) {
             case 2048: {
                 using fg = fused_globals<128, 128, 2>;
-                fg globals =
-                    ag_gemm_warp_specialized_make_globals<128, 128, 2>(A, A_local_buf, B, C, dev_idx, M, N);
+                fg globals = ag_gemm_warp_specialized_make_globals<128, 128, 2>(
+                    A, A_local_buf, B, C, dev_idx, M, N);
                 launch_ag_gemm_warp_specialized<128, 128, 2, 15>(globals);
                 break;
             }
             case 3072: {
                 using fg = fused_globals<128, 256, 2>;
-                fg globals =
-                    ag_gemm_warp_specialized_make_globals<128, 256, 2>(A, A_local_buf, B, C, dev_idx, M, N);
+                fg globals = ag_gemm_warp_specialized_make_globals<128, 256, 2>(
+                    A, A_local_buf, B, C, dev_idx, M, N);
                 launch_ag_gemm_warp_specialized<128, 256, 2, 15>(globals);
                 break;
             }
             case 3584: {
                 using fg = fused_globals<128, 256, 2>;
-                fg globals =
-                    ag_gemm_warp_specialized_make_globals<128, 256, 2>(A, A_local_buf, B, C, dev_idx, M, N);
+                fg globals = ag_gemm_warp_specialized_make_globals<128, 256, 2>(
+                    A, A_local_buf, B, C, dev_idx, M, N);
                 launch_ag_gemm_warp_specialized<128, 256, 2, 20>(globals);
                 break;
             }
             case 4096: {
                 using fg = fused_globals<128, 256, 2>;
-                fg globals =
-                    ag_gemm_warp_specialized_make_globals<128, 256, 2>(A, A_local_buf, B, C, dev_idx, M, N);
+                fg globals = ag_gemm_warp_specialized_make_globals<128, 256, 2>(
+                    A, A_local_buf, B, C, dev_idx, M, N);
                 launch_ag_gemm_warp_specialized<128, 256, 2, 5>(globals);
                 break;
             }
             case 8192: {
                 using fg = fused_globals<128, 256, 2>;
-                fg globals =
-                    ag_gemm_warp_specialized_make_globals<128, 256, 2>(A, A_local_buf, B, C, dev_idx, M, N);
+                fg globals = ag_gemm_warp_specialized_make_globals<128, 256, 2>(
+                    A, A_local_buf, B, C, dev_idx, M, N);
                 launch_ag_gemm_warp_specialized<128, 256, 2, 20>(globals);
                 break;
             }
             case 16384: {
-                using fg = fused_globals<128, 256, 2>;
-                fg globals =
-                    ag_gemm_warp_specialized_make_globals<128, 256, 2>(A, A_local_buf, B, C, dev_idx, M, N);
-                launch_ag_gemm_warp_specialized<128, 256, 2, 5>(globals);
+                // 2-consumer-warp, 2-CTA path: KDA at this shape divides
+                // evenly across NUM_CLUSTERS * NUM_CONSUMER_WARPS.
+                using fg = fused_globals<128, 256, 2, 2>;
+                fg globals = ag_gemm_warp_specialized_make_globals<128, 256, 2, 2>(
+                    A, A_local_buf, B, C, dev_idx, M, N);
+                launch_ag_gemm_warp_specialized<128, 256, 2, 5, 2>(globals);
                 break;
             }
             case 32768: {
-                using fg = fused_globals<128, 256, 2>;
-                fg globals =
-                    ag_gemm_warp_specialized_make_globals<128, 256, 2>(A, A_local_buf, B, C, dev_idx, M, N);
-                launch_ag_gemm_warp_specialized<128, 256, 2, 10>(globals);
+                // 2-consumer-warp, 2-CTA path: KDA at this shape divides
+                // evenly across NUM_CLUSTERS * NUM_CONSUMER_WARPS.
+                using fg = fused_globals<128, 256, 2, 2>;
+                fg globals = ag_gemm_warp_specialized_make_globals<128, 256, 2, 2>(
+                    A, A_local_buf, B, C, dev_idx, M, N);
+                launch_ag_gemm_warp_specialized<128, 256, 2, 10, 2>(globals);
                 break;
             }
             default:
@@ -251,51 +268,53 @@ void entrypoint(dist::ParallelBuffer& A,
         switch (logical_global_m) {
             case 2048: {
                 using fg = fused_globals<128, 128, 2>;
-                fg globals =
-                    ag_gemm_warp_specialized_make_globals<128, 128, 2>(A, A_local_buf, B, C, dev_idx, M, N);
+                fg globals = ag_gemm_warp_specialized_make_globals<128, 128, 2>(
+                    A, A_local_buf, B, C, dev_idx, M, N);
                 launch_ag_gemm_warp_specialized<128, 128, 2, 25>(globals);
                 break;
             }
             case 3072: {
                 using fg = fused_globals<128, 128, 1>;
-                fg globals =
-                    ag_gemm_warp_specialized_make_globals<128, 128, 1>(A, A_local_buf, B, C, dev_idx, M, N);
+                fg globals = ag_gemm_warp_specialized_make_globals<128, 128, 1>(
+                    A, A_local_buf, B, C, dev_idx, M, N);
                 launch_ag_gemm_warp_specialized<128, 128, 1, 20>(globals);
                 break;
             }
             case 3584: {
                 using fg = fused_globals<128, 256, 2>;
-                fg globals =
-                    ag_gemm_warp_specialized_make_globals<128, 256, 2>(A, A_local_buf, B, C, dev_idx, M, N);
+                fg globals = ag_gemm_warp_specialized_make_globals<128, 256, 2>(
+                    A, A_local_buf, B, C, dev_idx, M, N);
                 launch_ag_gemm_warp_specialized<128, 256, 2, 10>(globals);
                 break;
             }
             case 4096: {
                 using fg = fused_globals<128, 256, 2>;
-                fg globals =
-                    ag_gemm_warp_specialized_make_globals<128, 256, 2>(A, A_local_buf, B, C, dev_idx, M, N);
+                fg globals = ag_gemm_warp_specialized_make_globals<128, 256, 2>(
+                    A, A_local_buf, B, C, dev_idx, M, N);
                 launch_ag_gemm_warp_specialized<128, 256, 2, 10>(globals);
                 break;
             }
             case 8192: {
                 using fg = fused_globals<128, 256, 2>;
-                fg globals =
-                    ag_gemm_warp_specialized_make_globals<128, 256, 2>(A, A_local_buf, B, C, dev_idx, M, N);
+                fg globals = ag_gemm_warp_specialized_make_globals<128, 256, 2>(
+                    A, A_local_buf, B, C, dev_idx, M, N);
                 launch_ag_gemm_warp_specialized<128, 256, 2, 10>(globals);
                 break;
             }
             case 16384: {
                 using fg = fused_globals<128, 256, 2>;
-                fg globals =
-                    ag_gemm_warp_specialized_make_globals<128, 256, 2>(A, A_local_buf, B, C, dev_idx, M, N);
+                fg globals = ag_gemm_warp_specialized_make_globals<128, 256, 2>(
+                    A, A_local_buf, B, C, dev_idx, M, N);
                 launch_ag_gemm_warp_specialized<128, 256, 2, 15>(globals);
                 break;
             }
             case 32768: {
-                using fg = fused_globals<128, 256, 2>;
-                fg globals =
-                    ag_gemm_warp_specialized_make_globals<128, 256, 2>(A, A_local_buf, B, C, dev_idx, M, N);
-                launch_ag_gemm_warp_specialized<128, 256, 2, 20>(globals);
+                // 2-consumer-warp, 2-CTA path: MLA at this shape divides
+                // evenly across NUM_CLUSTERS * NUM_CONSUMER_WARPS.
+                using fg = fused_globals<128, 256, 2, 2>;
+                fg globals = ag_gemm_warp_specialized_make_globals<128, 256, 2, 2>(
+                    A, A_local_buf, B, C, dev_idx, M, N);
+                launch_ag_gemm_warp_specialized<128, 256, 2, 20, 2>(globals);
                 break;
             }
             default:

--- a/include/operators/ag_gemm/ag_gemm_warp_specialized.cuh
+++ b/include/operators/ag_gemm/ag_gemm_warp_specialized.cuh
@@ -215,36 +215,36 @@ void entrypoint(dist::ParallelBuffer& A,
         switch (logical_global_m) {
             case 2048: {
                 using fg = fused_globals<128, 128, 2>;
-                fg globals = ag_gemm_warp_specialized_make_globals<128, 128, 2>(
-                    A, A_local_buf, B, C, dev_idx, M, N);
+                fg globals =
+                    ag_gemm_warp_specialized_make_globals<128, 128, 2>(A, A_local_buf, B, C, dev_idx, M, N);
                 launch_ag_gemm_warp_specialized<128, 128, 2, 15>(globals);
                 break;
             }
             case 3072: {
                 using fg = fused_globals<128, 256, 2>;
-                fg globals = ag_gemm_warp_specialized_make_globals<128, 256, 2>(
-                    A, A_local_buf, B, C, dev_idx, M, N);
+                fg globals =
+                    ag_gemm_warp_specialized_make_globals<128, 256, 2>(A, A_local_buf, B, C, dev_idx, M, N);
                 launch_ag_gemm_warp_specialized<128, 256, 2, 15>(globals);
                 break;
             }
             case 3584: {
                 using fg = fused_globals<128, 256, 2>;
-                fg globals = ag_gemm_warp_specialized_make_globals<128, 256, 2>(
-                    A, A_local_buf, B, C, dev_idx, M, N);
+                fg globals =
+                    ag_gemm_warp_specialized_make_globals<128, 256, 2>(A, A_local_buf, B, C, dev_idx, M, N);
                 launch_ag_gemm_warp_specialized<128, 256, 2, 20>(globals);
                 break;
             }
             case 4096: {
                 using fg = fused_globals<128, 256, 2>;
-                fg globals = ag_gemm_warp_specialized_make_globals<128, 256, 2>(
-                    A, A_local_buf, B, C, dev_idx, M, N);
+                fg globals =
+                    ag_gemm_warp_specialized_make_globals<128, 256, 2>(A, A_local_buf, B, C, dev_idx, M, N);
                 launch_ag_gemm_warp_specialized<128, 256, 2, 5>(globals);
                 break;
             }
             case 8192: {
                 using fg = fused_globals<128, 256, 2, 2>;
-                fg globals = ag_gemm_warp_specialized_make_globals<128, 256, 2, 2>(
-                    A, A_local_buf, B, C, dev_idx, M, N);
+                fg globals =
+                    ag_gemm_warp_specialized_make_globals<128, 256, 2, 2>(A, A_local_buf, B, C, dev_idx, M, N);
                 launch_ag_gemm_warp_specialized<128, 256, 2, 5, 2>(globals);
                 break;
             }
@@ -252,8 +252,8 @@ void entrypoint(dist::ParallelBuffer& A,
                 // 2-consumer-warp, 2-CTA path: KDA at this shape divides
                 // evenly across NUM_CLUSTERS * NUM_CONSUMER_WARPS.
                 using fg = fused_globals<128, 256, 2, 2>;
-                fg globals = ag_gemm_warp_specialized_make_globals<128, 256, 2, 2>(
-                    A, A_local_buf, B, C, dev_idx, M, N);
+                fg globals =
+                    ag_gemm_warp_specialized_make_globals<128, 256, 2, 2>(A, A_local_buf, B, C, dev_idx, M, N);
                 launch_ag_gemm_warp_specialized<128, 256, 2, 5, 2>(globals);
                 break;
             }
@@ -261,8 +261,8 @@ void entrypoint(dist::ParallelBuffer& A,
                 // 2-consumer-warp, 2-CTA path: KDA at this shape divides
                 // evenly across NUM_CLUSTERS * NUM_CONSUMER_WARPS.
                 using fg = fused_globals<128, 256, 2, 2>;
-                fg globals = ag_gemm_warp_specialized_make_globals<128, 256, 2, 2>(
-                    A, A_local_buf, B, C, dev_idx, M, N);
+                fg globals =
+                    ag_gemm_warp_specialized_make_globals<128, 256, 2, 2>(A, A_local_buf, B, C, dev_idx, M, N);
                 launch_ag_gemm_warp_specialized<128, 256, 2, 5, 2>(globals);
                 break;
             }
@@ -273,50 +273,50 @@ void entrypoint(dist::ParallelBuffer& A,
         switch (logical_global_m) {
             case 2048: {
                 using fg = fused_globals<128, 128, 2>;
-                fg globals = ag_gemm_warp_specialized_make_globals<128, 128, 2>(
-                    A, A_local_buf, B, C, dev_idx, M, N);
+                fg globals =
+                    ag_gemm_warp_specialized_make_globals<128, 128, 2>(A, A_local_buf, B, C, dev_idx, M, N);
                 launch_ag_gemm_warp_specialized<128, 128, 2, 25>(globals);
                 break;
             }
             case 3072: {
                 using fg = fused_globals<128, 128, 1>;
-                fg globals = ag_gemm_warp_specialized_make_globals<128, 128, 1>(
-                    A, A_local_buf, B, C, dev_idx, M, N);
+                fg globals =
+                    ag_gemm_warp_specialized_make_globals<128, 128, 1>(A, A_local_buf, B, C, dev_idx, M, N);
                 launch_ag_gemm_warp_specialized<128, 128, 1, 20>(globals);
                 break;
             }
             case 3584: {
                 using fg = fused_globals<128, 256, 2>;
-                fg globals = ag_gemm_warp_specialized_make_globals<128, 256, 2>(
-                    A, A_local_buf, B, C, dev_idx, M, N);
+                fg globals =
+                    ag_gemm_warp_specialized_make_globals<128, 256, 2>(A, A_local_buf, B, C, dev_idx, M, N);
                 launch_ag_gemm_warp_specialized<128, 256, 2, 10>(globals);
                 break;
             }
             case 4096: {
                 using fg = fused_globals<128, 256, 2>;
-                fg globals = ag_gemm_warp_specialized_make_globals<128, 256, 2>(
-                    A, A_local_buf, B, C, dev_idx, M, N);
+                fg globals =
+                    ag_gemm_warp_specialized_make_globals<128, 256, 2>(A, A_local_buf, B, C, dev_idx, M, N);
                 launch_ag_gemm_warp_specialized<128, 256, 2, 10>(globals);
                 break;
             }
             case 8192: {
                 using fg = fused_globals<128, 256, 2>;
-                fg globals = ag_gemm_warp_specialized_make_globals<128, 256, 2>(
-                    A, A_local_buf, B, C, dev_idx, M, N);
+                fg globals =
+                    ag_gemm_warp_specialized_make_globals<128, 256, 2>(A, A_local_buf, B, C, dev_idx, M, N);
                 launch_ag_gemm_warp_specialized<128, 256, 2, 10>(globals);
                 break;
             }
             case 16384: {
                 using fg = fused_globals<128, 256, 2>;
-                fg globals = ag_gemm_warp_specialized_make_globals<128, 256, 2>(
-                    A, A_local_buf, B, C, dev_idx, M, N);
+                fg globals =
+                    ag_gemm_warp_specialized_make_globals<128, 256, 2>(A, A_local_buf, B, C, dev_idx, M, N);
                 launch_ag_gemm_warp_specialized<128, 256, 2, 15>(globals);
                 break;
             }
             case 32768: {
                 using fg = fused_globals<128, 256, 2, 1>;
-                fg globals = ag_gemm_warp_specialized_make_globals<128, 256, 2, 1>(
-                    A, A_local_buf, B, C, dev_idx, M, N);
+                fg globals =
+                    ag_gemm_warp_specialized_make_globals<128, 256, 2, 1>(A, A_local_buf, B, C, dev_idx, M, N);
                 launch_ag_gemm_warp_specialized<128, 256, 2, 15, 1>(globals);
                 break;
             }

--- a/include/operators/ag_gemm/ag_gemm_warp_specialized.cuh
+++ b/include/operators/ag_gemm/ag_gemm_warp_specialized.cuh
@@ -208,7 +208,7 @@ void entrypoint(dist::ParallelBuffer& A,
                 "A.local_world_size must match the compiled INTRA_NUM_DEVICES");
 
     // TODO: this only works for TP == 8
-    constexpr int KDA_N = 6400;
+    constexpr int KDA_N = 6288;
 
     // use size of N to check which projection is being done
     if (N == KDA_N) {

--- a/src/ag_gemm_warp_specialized.cu
+++ b/src/ag_gemm_warp_specialized.cu
@@ -113,10 +113,14 @@ __device__ __forceinline__ std::tuple<int, int> calculate_tile_idx(int num_rows,
     return {(supergroup_idx & 1) ? num_rows - row_idx - 1 : row_idx, col_idx};
 };
 
-template <int _ROW_BLOCK, int _COL_BLOCK, int _NUM_CTA, int SUPERGROUP_WIDTH>
+template <int _ROW_BLOCK,
+          int _COL_BLOCK,
+          int _NUM_CTA,
+          int SUPERGROUP_WIDTH,
+          int _NUM_CONSUMER_WARPS>
 __device__ __forceinline__ void ag_gemm_warp_specialized(
-    const fused_globals<_ROW_BLOCK, _COL_BLOCK, _NUM_CTA>& G) {
-    using fg = fused_globals<_ROW_BLOCK, _COL_BLOCK, _NUM_CTA>;
+    const fused_globals<_ROW_BLOCK, _COL_BLOCK, _NUM_CTA, _NUM_CONSUMER_WARPS>& G) {
+    using fg = fused_globals<_ROW_BLOCK, _COL_BLOCK, _NUM_CTA, _NUM_CONSUMER_WARPS>;
 
     const int cta_rank = cluster_ctarank();
     const int warp_id = warpid();
@@ -132,7 +136,8 @@ __device__ __forceinline__ void ag_gemm_warp_specialized(
     const int cluster_idx = blockIdx.x / fg::NUM_CLUSTERS;
     const int local_m = G.A.rows();
     const int row_tiles_per_device = local_m / fg::ROW_BLOCK;
-    const int cluster_rows_per_device = row_tiles_per_device / fg::NUM_CLUSTERS;
+    const int cluster_rows_per_device =
+        row_tiles_per_device / fg::NUM_CLUSTERS / fg::CONSUMER_WARPS;
     const int num_comp_clusters = fg::NUM_BLOCKS / fg::NUM_CLUSTERS;
 
     // round up to the nearest multiple of the COL_BLOCK
@@ -151,8 +156,8 @@ __device__ __forceinline__ void ag_gemm_warp_specialized(
     __shared__ semaphore tma_load[fg::PRODUCER_CONSUMER_PIPELINE_STAGES];
     __shared__ semaphore mma_finish[fg::PRODUCER_CONSUMER_PIPELINE_STAGES];
 
-    __shared__ semaphore epilogue_ready[fg::TMEM_PIPELINE_STAGES];
-    __shared__ semaphore epilogue_tmem_finished[fg::TMEM_PIPELINE_STAGES];
+    __shared__ semaphore epilogue_ready[fg::NUM_TMEM_SLOTS];
+    __shared__ semaphore epilogue_tmem_finished[fg::NUM_TMEM_SLOTS];
 
     __shared__ semaphore tmem_allocated;
     __shared__ semaphore tmem_finished;
@@ -168,12 +173,13 @@ __device__ __forceinline__ void ag_gemm_warp_specialized(
             // tma finish has to be broadcasted to mma warp
             init_semaphore(tma_load[i], 0, fg::NUM_CLUSTERS);
             // mma warp will broadcast finish
-            init_semaphore(mma_finish[i], 0, 1);
+            init_semaphore(mma_finish[i], 0, fg::CONSUMER_WARPS);
         }
 
 #pragma unroll
-        for (int i = 0; i < fg::TMEM_PIPELINE_STAGES; i++) {
+        for (int i = 0; i < fg::NUM_TMEM_SLOTS; i++) {
             init_semaphore(epilogue_ready[i], 0, 1);
+
             // tmem finish has to be broadcasted back
             init_semaphore(epilogue_tmem_finished[i], WARPGROUP_WARPS * fg::NUM_CLUSTERS);
         }
@@ -202,18 +208,26 @@ __device__ __forceinline__ void ag_gemm_warp_specialized(
 
         const typename fg::A_local_tensor& A_gmem =
             is_local ? G.A[actual_target_device] : G.A_local_buf;
-        const int A_tile_row_idx =
-            is_local ? tile_row_idx : actual_target_device * row_tiles_per_device + tile_row_idx;
+
+        // tile_row_idx is consumer 0's row tile; each additional consumer
+        // warp c owns the row tile NUM_CLUSTERS further along -- see the
+        // matching offset in the consumer/epilogue loops below.
+        auto a_tile_row_idx_for = [&](int c) {
+            const int local_row = tile_row_idx + c * fg::NUM_CLUSTERS;
+            return is_local ? local_row : actual_target_device * row_tiles_per_device + local_row;
+        };
 
         for (int iter_k = 0; iter_k < G.K / fg::RED_BLOCK; iter_k++) {
-            typename fg::A_tile& A_smem = inputs_smem[input_stage_id].A;
+            typename fg::A_tile(&A_smem)[fg::CONSUMER_WARPS] = inputs_smem[input_stage_id].A;
             typename fg::B_tile& B_smem = inputs_smem[input_stage_id].B;
 
             wait(mma_finish[input_stage_id], (phasebits >> 0 & 0b1));
 
             if constexpr (_NUM_CTA == 2) {
                 tma::cluster::expect_bytes(
-                    tma_load[input_stage_id], sizeof(fg::A_tile) + sizeof(fg::B_tile), 0);
+                    tma_load[input_stage_id],
+                    sizeof(fg::A_tile) * fg::CONSUMER_WARPS + sizeof(fg::B_tile),
+                    0);
 
                 // B_tile is [N, K], so the TMA coordinate is (n_tile, k_tile),
                 // not (k_tile, n_tile).
@@ -224,19 +238,23 @@ __device__ __forceinline__ void ag_gemm_warp_specialized(
                                          (uint16_t)(1 << cta_rank),
                                          0);
 
-                tma::cluster::load_async(A_smem,
-                                         A_gmem,
-                                         {A_tile_row_idx, iter_k},
-                                         tma_load[input_stage_id],
-                                         (uint16_t)(1 << cta_rank),
-                                         0);
+#pragma unroll
+                for (int c = 0; c < fg::CONSUMER_WARPS; c++) {
+                    tma::cluster::load_async(A_smem[c],
+                                             A_gmem,
+                                             {a_tile_row_idx_for(c), iter_k},
+                                             tma_load[input_stage_id],
+                                             (uint16_t)(1 << cta_rank),
+                                             0);
+                }
+
             } else {
                 // A 1-CTA cluster has nothing to multicast to and nothing to
                 // map: the barrier is this CTA's own. The cluster overloads
                 // would still emit cta_group::2.multicast::cluster loads, so
                 // take the plain CTA-scope TMA path instead.
                 tma::expect_bytes(tma_load[input_stage_id],
-                                  sizeof(fg::A_tile) + sizeof(fg::B_tile));
+                                  sizeof(fg::A_tile) * fg::CONSUMER_WARPS + sizeof(fg::B_tile));
 
                 // B_tile is [N, K], so the TMA coordinate is (n_tile, k_tile),
                 // not (k_tile, n_tile).
@@ -245,7 +263,11 @@ __device__ __forceinline__ void ag_gemm_warp_specialized(
                                 {tile_col_idx * fg::NUM_CLUSTERS + cta_rank, iter_k},
                                 tma_load[input_stage_id]);
 
-                tma::load_async(A_smem, A_gmem, {A_tile_row_idx, iter_k}, tma_load[input_stage_id]);
+#pragma unroll
+                for (int c = 0; c < fg::CONSUMER_WARPS; c++) {
+                    tma::load_async(
+                        A_smem[c], A_gmem, {a_tile_row_idx_for(c), iter_k}, tma_load[input_stage_id]);
+                }
             }
 
             input_stage_id = (input_stage_id + 1) % fg::PRODUCER_CONSUMER_PIPELINE_STAGES;
@@ -254,11 +276,16 @@ __device__ __forceinline__ void ag_gemm_warp_specialized(
             }
         }
     };
-    auto consume = [&](typename fg::C_tt_tile* tmem, int& input_stage_id, int& epilogue_stage_id) {
-        wait(epilogue_tmem_finished[epilogue_stage_id], (phasebits >> 2) & 0b1);
+    auto consume = [&](typename fg::C_tt_tile* tmem,
+                       int& input_stage_id,
+                       int& epilogue_stage_id,
+                       const int consumer_id) {
+        const int consumer_semaphore_idx = consumer_id + 2;
+        wait(epilogue_tmem_finished[epilogue_stage_id * fg::CONSUMER_WARPS + consumer_id],
+             (phasebits >> consumer_semaphore_idx) & 0b1);
 
         {
-            typename fg::A_tile& A_smem = inputs_smem[input_stage_id].A;
+            typename fg::A_tile& A_smem = inputs_smem[input_stage_id].A[consumer_id];
             typename fg::B_tile& B_smem = inputs_smem[input_stage_id].B;
             wait(tma_load[input_stage_id], (phasebits >> 1) & 0b1);
 
@@ -272,7 +299,7 @@ __device__ __forceinline__ void ag_gemm_warp_specialized(
         }
 
         for (int iter_k = 1; iter_k < G.K / fg::RED_BLOCK; iter_k++) {
-            typename fg::A_tile& A_smem = inputs_smem[input_stage_id].A;
+            typename fg::A_tile& A_smem = inputs_smem[input_stage_id].A[consumer_id];
             typename fg::B_tile& B_smem = inputs_smem[input_stage_id].B;
             wait(tma_load[input_stage_id], (phasebits >> 1) & 0b1);
 
@@ -285,17 +312,19 @@ __device__ __forceinline__ void ag_gemm_warp_specialized(
             }
         }
 
-        kittens::detail::tcgen05::commit<fg::NUM_CLUSTERS>(epilogue_ready[epilogue_stage_id]);
+        kittens::detail::tcgen05::commit<fg::NUM_CLUSTERS>(
+            epilogue_ready[epilogue_stage_id * fg::CONSUMER_WARPS + consumer_id]);
         epilogue_stage_id = (epilogue_stage_id + 1) % fg::TMEM_PIPELINE_STAGES;
 
         if (epilogue_stage_id == 0) {
-            phasebits ^= (1 << 2);
+            phasebits ^= (1 << consumer_semaphore_idx);
         }
     };
 
     auto epilogue = [&](int tile_row_idx,
                         int tile_col_idx,
                         typename fg::C_tt_tile* tmem,
+                        const int consumer_id,
                         int& epilogue_stage_id,
                         int& epilogue_transfer_stage_id,
                         bool is_last_tile) {
@@ -303,7 +332,12 @@ __device__ __forceinline__ void ag_gemm_warp_specialized(
         constexpr int C_CHUNK_COLS = fg::COL_BLOCK / fg::C_TILE_DIVISOR;
         rt_bf<fg::ROW_BLOCK / WARPGROUP_WARPS, C_CHUNK_COLS> c_reg[fg::C_TILE_DIVISOR];
 
-        wait(epilogue_ready[epilogue_stage_id], (phasebits >> 3) & 0b1);
+        // Mirrors consume()'s consumer_semaphore_idx (bits [2, 2+CONSUMER_WARPS)):
+        // this is the other end of the same per-consumer double-buffer, using
+        // the next CONSUMER_WARPS bits so the two phases never alias.
+        const int epilogue_semaphore_idx = 2 + fg::CONSUMER_WARPS + consumer_id;
+        wait(epilogue_ready[epilogue_stage_id * fg::CONSUMER_WARPS + consumer_id],
+             (phasebits >> epilogue_semaphore_idx) & 0b1);
 
 #pragma unroll
         for (int i = 0; i < fg::C_TILE_DIVISOR; i++) {
@@ -318,13 +352,17 @@ __device__ __forceinline__ void ag_gemm_warp_specialized(
 
         if (elect_warp_leader()) {
             if constexpr (_NUM_CTA == 2) {
-                tma::cluster::arrive(epilogue_tmem_finished[epilogue_stage_id], 0);
+                tma::cluster::arrive(
+                    epilogue_tmem_finished[epilogue_stage_id * fg::CONSUMER_WARPS + consumer_id],
+                    0);
             } else {
                 arrive(epilogue_tmem_finished[epilogue_stage_id]);
             }
         }
 
-        if (is_last_tile) {
+        // Only the last consumer warp's pass over the final tile should
+        // signal PDL -- firing it once per consumer would be redundant.
+        if (is_last_tile && consumer_id == fg::CONSUMER_WARPS - 1) {
             warpgroup::sync(1);
             pdl::arrive();
         }
@@ -353,7 +391,7 @@ __device__ __forceinline__ void ag_gemm_warp_specialized(
 
         epilogue_stage_id = (epilogue_stage_id + 1) % fg::TMEM_PIPELINE_STAGES;
         if (epilogue_stage_id == 0) {
-            phasebits ^= (0b1 << 3);
+            phasebits ^= (0b1 << epilogue_semaphore_idx);
         }
     };
 
@@ -372,7 +410,7 @@ __device__ __forceinline__ void ag_gemm_warp_specialized(
 
                     int target_device = tile_id / cluster_tiles_per_device;
 
-                    load(local_row_id * fg::NUM_CLUSTERS + cta_rank,
+                    load(local_row_id * fg::NUM_CLUSTERS * fg::CONSUMER_WARPS + cta_rank,
                          tile_col_idx,
                          target_device,
                          input_stage_id);
@@ -380,64 +418,87 @@ __device__ __forceinline__ void ag_gemm_warp_specialized(
             }
 
             pdl::arrive();
-        } else if (warp_id == 5) {
+        } else if (warp_id < 5 + _NUM_CONSUMER_WARPS) {
             int input_stage_id = 0;
             int epilogue_stage_id = 0;
             typename fg::C_tt_tile tmem[fg::TMEM_PIPELINE_STAGES];
+            // warp 4 is the producer, so the first consumer warp is warp 5.
+            const int consumer_warp_id = warp_id - 5;
 
             // wait for PDL
             pdl::wait();
             everyone::tma::cluster::wait();
-            tm_alloc.provision(tmem_addr);
-            tm_alloc.set_addr(tmem_addr);
 
-            if (elect_warp_leader()) {
-                arrive(tmem_allocated);
+            if (warp_id == 5) {
+                tm_alloc.provision(tmem_addr);
+                if (elect_warp_leader()) {
+                    arrive(tmem_allocated);
+                }
+                tm_alloc.set_addr(tmem_addr);
+            } else {
+                wait(tmem_allocated, 0);
+                tm_alloc.set_addr(tmem_addr);
             }
 
             if (cta_rank == 0 && elect_warp_leader()) {
 #pragma unroll
                 for (int i = 0; i < fg::TMEM_PIPELINE_STAGES; i++) {
-                    tmem[i] = tm_alloc.template allocate<fg::C_tt_tile>(i * fg::COL_BLOCK);
+                    // Each consumer warp owns its own contiguous
+                    // TMEM_PIPELINE_STAGES * COL_BLOCK column range so the
+                    // two consumers' pipelines never alias in tensor memory.
+                    tmem[i] = tm_alloc.template allocate<fg::C_tt_tile>(
+                        (consumer_warp_id * fg::TMEM_PIPELINE_STAGES + i) * fg::COL_BLOCK);
                 }
 
-                for (int tile_id = cluster_idx;
-                     tile_id < cluster_tiles_per_device * fg::NUM_DEVICES;
+                for (int tile_id = cluster_idx; tile_id < total_num_tiles;
                      tile_id += num_comp_clusters) {
-                    consume(tmem, input_stage_id, epilogue_stage_id);
+                    consume(tmem, input_stage_id, epilogue_stage_id, consumer_warp_id);
                 }
             }
 
             pdl::arrive();
         }
     } else {
-        int epilogue_stage_id = 0;
+        // Each consumer warp has its own TMEM_PIPELINE_STAGES cycle (they
+        // produce independently), so track their stage counters separately;
+        // the SMEM transfer FIFO is a single shared resource, so one counter
+        // for it is correct regardless of consumer count.
+        int epilogue_stage_id[fg::CONSUMER_WARPS] = {};
         int epilogue_transfer_stage_id = 0;
-        typename fg::C_tt_tile tmem[fg::TMEM_PIPELINE_STAGES];
+        typename fg::C_tt_tile tmem[fg::NUM_TMEM_SLOTS];
 
         // wait for PDL and tmem
         everyone::tma::cluster::wait();
         wait(tmem_allocated, 0);
 
 #pragma unroll
-        for (int i = 0; i < fg::TMEM_PIPELINE_STAGES; i++) {
+        for (int i = 0; i < fg::NUM_TMEM_SLOTS; i++) {
+            // Matches the consumer warps' allocation: consumer c's stages
+            // live at columns [c * TMEM_PIPELINE_STAGES, (c+1) * TMEM_PIPELINE_STAGES).
             tmem[i] = tm_alloc.template allocate<fg::C_tt_tile>(i * fg::COL_BLOCK);
         }
 
         for (int tile_id = cluster_idx; tile_id < total_num_tiles; tile_id += num_comp_clusters) {
             // work should be partitioned based on the rank tile size. M = GLOBAL_M / TP
-            auto [local_tile_row, tile_col_idx] = calculate_tile_idx<SUPERGROUP_WIDTH>(
+            auto [local_row_id, tile_col_idx] = calculate_tile_idx<SUPERGROUP_WIDTH>(
                 cluster_rows_per_device, num_col_tiles, tile_id % cluster_tiles_per_device);
-
             const int target_device =
                 (tile_id / cluster_tiles_per_device + G.dev_idx) % fg::NUM_DEVICES;
-            const int local_cta_row = local_tile_row * fg::NUM_CLUSTERS + cta_rank;
-            epilogue(target_device * row_tiles_per_device + local_cta_row,
-                     tile_col_idx,
-                     tmem,
-                     epilogue_stage_id,
-                     epilogue_transfer_stage_id,
-                     tile_id + num_comp_clusters >= total_num_tiles);
+
+#pragma unroll
+            for (int c = 0; c < fg::CONSUMER_WARPS; c++) {
+                // Matches the load()/consume() row offset: consumer c owns
+                // the row tile NUM_CLUSTERS further along than consumer 0.
+                const int local_cta_row =
+                    (local_row_id * fg::CONSUMER_WARPS + c) * fg::NUM_CLUSTERS + cta_rank;
+                epilogue(target_device * row_tiles_per_device + local_cta_row,
+                         tile_col_idx,
+                         &tmem[c * fg::TMEM_PIPELINE_STAGES],
+                         c,
+                         epilogue_stage_id[c],
+                         epilogue_transfer_stage_id,
+                         tile_id + num_comp_clusters >= total_num_tiles);
+            }
         }
 
         // wait for store to complete before deallocation of tmem
@@ -466,21 +527,38 @@ __device__ __forceinline__ void ag_gemm_warp_specialized(
     }
 }
 
-template <int _ROW_BLOCK, int _COL_BLOCK, int _NUM_CTA, int SUPERGROUP_WIDTH>
-__global__ __cluster_dims__(fused_globals<_ROW_BLOCK, _COL_BLOCK, _NUM_CTA>::NUM_CLUSTERS, 1, 1)
+template <int _ROW_BLOCK,
+          int _COL_BLOCK,
+          int _NUM_CTA,
+          int SUPERGROUP_WIDTH,
+          int _NUM_CONSUMER_WARPS>
+__global__ __cluster_dims__(
+    fused_globals<_ROW_BLOCK, _COL_BLOCK, _NUM_CTA, _NUM_CONSUMER_WARPS>::NUM_CLUSTERS,
+    1,
+    1)
     __launch_bounds__(
-        fused_globals<_ROW_BLOCK, _COL_BLOCK, _NUM_CTA>::NUM_THREADS,
-        1) void fused_kernel_stub(const __grid_constant__
-                                      fused_globals<_ROW_BLOCK, _COL_BLOCK, _NUM_CTA> G) {
-    ag_gemm_warp_specialized<_ROW_BLOCK, _COL_BLOCK, _NUM_CTA, SUPERGROUP_WIDTH>(G);
+        fused_globals<_ROW_BLOCK, _COL_BLOCK, _NUM_CTA, _NUM_CONSUMER_WARPS>::NUM_THREADS,
+        1) void fused_kernel_stub(const __grid_constant__ fused_globals<_ROW_BLOCK,
+                                                                        _COL_BLOCK,
+                                                                        _NUM_CTA,
+                                                                        _NUM_CONSUMER_WARPS> G) {
+    ag_gemm_warp_specialized<_ROW_BLOCK,
+                             _COL_BLOCK,
+                             _NUM_CTA,
+                             SUPERGROUP_WIDTH,
+                             _NUM_CONSUMER_WARPS>(G);
 }
 
-template <int _ROW_BLOCK, int _COL_BLOCK, int _NUM_CTA, int SUPERGROUP_WIDTH>
+template <int _ROW_BLOCK,
+          int _COL_BLOCK,
+          int _NUM_CTA,
+          int SUPERGROUP_WIDTH,
+          int _NUM_CONSUMER_WARPS>
 inline void launch_ag_gemm_warp_specialized(
-    const fused_globals<_ROW_BLOCK, _COL_BLOCK, _NUM_CTA>& G) {
+    const fused_globals<_ROW_BLOCK, _COL_BLOCK, _NUM_CTA, _NUM_CONSUMER_WARPS>& G) {
     cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
-    using fg = fused_globals<_ROW_BLOCK, _COL_BLOCK, _NUM_CTA>;
+    using fg = fused_globals<_ROW_BLOCK, _COL_BLOCK, _NUM_CTA, _NUM_CONSUMER_WARPS>;
     static_assert(fg::SMEM_FITS, "SMEM allocation too large for this config");
     ACopyPipelineState& copy_state = get_A_copy_state(G.dev_idx);
 
@@ -528,7 +606,8 @@ inline void launch_ag_gemm_warp_specialized(
     constexpr int num_threads = fg::NUM_THREADS;
     constexpr int grid = fg::NUM_BLOCKS;
 
-    auto this_kernel = fused_kernel_stub<_ROW_BLOCK, _COL_BLOCK, _NUM_CTA, SUPERGROUP_WIDTH>;
+    auto this_kernel =
+        fused_kernel_stub<_ROW_BLOCK, _COL_BLOCK, _NUM_CTA, SUPERGROUP_WIDTH, _NUM_CONSUMER_WARPS>;
 
     MKERNEL_CUDACHECK(
         cudaFuncSetAttribute(this_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));

--- a/src/ag_gemm_warp_specialized.cu
+++ b/src/ag_gemm_warp_specialized.cu
@@ -135,9 +135,10 @@ __device__ __forceinline__ void ag_gemm_warp_specialized(
 
     const int cluster_idx = blockIdx.x / fg::NUM_CLUSTERS;
     const int local_m = G.A.rows();
-    const int row_tiles_per_device = local_m / fg::ROW_BLOCK;
+    const int row_tiles_per_device = (local_m + fg::ROW_BLOCK - 1) / fg::ROW_BLOCK;
     const int cluster_rows_per_device =
-        row_tiles_per_device / fg::NUM_CLUSTERS / fg::CONSUMER_WARPS;
+        (row_tiles_per_device + fg::NUM_CLUSTERS * fg::CONSUMER_WARPS - 1) /
+        (fg::NUM_CLUSTERS * fg::CONSUMER_WARPS);
     const int num_comp_clusters = fg::NUM_BLOCKS / fg::NUM_CLUSTERS;
 
     // round up to the nearest multiple of the COL_BLOCK
@@ -206,16 +207,10 @@ __device__ __forceinline__ void ag_gemm_warp_specialized(
             }
         }
 
-        const typename fg::A_local_tensor& A_gmem =
-            is_local ? G.A[actual_target_device] : G.A_local_buf;
-
         // tile_row_idx is consumer 0's row tile; each additional consumer
         // warp c owns the row tile NUM_CLUSTERS further along -- see the
         // matching offset in the consumer/epilogue loops below.
-        auto a_tile_row_idx_for = [&](int c) {
-            const int local_row = tile_row_idx + c * fg::NUM_CLUSTERS;
-            return is_local ? local_row : actual_target_device * row_tiles_per_device + local_row;
-        };
+        auto a_tile_row_idx_for = [&](int c) { return tile_row_idx + c * fg::NUM_CLUSTERS; };
 
         for (int iter_k = 0; iter_k < G.K / fg::RED_BLOCK; iter_k++) {
             typename fg::A_tile(&A_smem)[fg::CONSUMER_WARPS] = inputs_smem[input_stage_id].A;
@@ -240,12 +235,22 @@ __device__ __forceinline__ void ag_gemm_warp_specialized(
 
 #pragma unroll
                 for (int c = 0; c < fg::CONSUMER_WARPS; c++) {
-                    tma::cluster::load_async(A_smem[c],
-                                             A_gmem,
-                                             {a_tile_row_idx_for(c), iter_k},
-                                             tma_load[input_stage_id],
-                                             (uint16_t)(1 << cta_rank),
-                                             0);
+                    if (is_local) {
+                        tma::cluster::load_async(A_smem[c],
+                                                 G.A[G.dev_idx],
+                                                 {a_tile_row_idx_for(c), iter_k},
+                                                 tma_load[input_stage_id],
+                                                 (uint16_t)(1 << cta_rank),
+                                                 0);
+                    } else {
+                        tma::cluster::load_async(
+                            A_smem[c],
+                            G.A_local_buf,
+                            {actual_target_device, a_tile_row_idx_for(c), iter_k},
+                            tma_load[input_stage_id],
+                            (uint16_t)(1 << cta_rank),
+                            0);
+                    }
                 }
 
             } else {
@@ -265,8 +270,17 @@ __device__ __forceinline__ void ag_gemm_warp_specialized(
 
 #pragma unroll
                 for (int c = 0; c < fg::CONSUMER_WARPS; c++) {
-                    tma::load_async(
-                        A_smem[c], A_gmem, {a_tile_row_idx_for(c), iter_k}, tma_load[input_stage_id]);
+                    if (is_local) {
+                        tma::load_async(A_smem[c],
+                                        G.A[G.dev_idx],
+                                        {a_tile_row_idx_for(c), iter_k},
+                                        tma_load[input_stage_id]);
+                    } else {
+                        tma::load_async(A_smem[c],
+                                        G.A_local_buf,
+                                        {actual_target_device, a_tile_row_idx_for(c), iter_k},
+                                        tma_load[input_stage_id]);
+                    }
                 }
             }
 
@@ -321,7 +335,8 @@ __device__ __forceinline__ void ag_gemm_warp_specialized(
         }
     };
 
-    auto epilogue = [&](int tile_row_idx,
+    auto epilogue = [&](int target_device,
+                        int tile_row_idx,
                         int tile_col_idx,
                         typename fg::C_tt_tile* tmem,
                         const int consumer_id,
@@ -382,7 +397,7 @@ __device__ __forceinline__ void ag_gemm_warp_specialized(
                 dist::tma::store_async<dim::ROW, cache_policy::EVICT_FIRST>(
                     C_out,
                     C_smem[epilogue_transfer_stage_id],
-                    {tile_row_idx, tile_col_idx * fg::C_TILE_DIVISOR + i});
+                    {target_device, tile_row_idx, tile_col_idx * fg::C_TILE_DIVISOR + i});
             }
 
             epilogue_transfer_stage_id =
@@ -491,7 +506,8 @@ __device__ __forceinline__ void ag_gemm_warp_specialized(
                 // the row tile NUM_CLUSTERS further along than consumer 0.
                 const int local_cta_row =
                     (local_row_id * fg::CONSUMER_WARPS + c) * fg::NUM_CLUSTERS + cta_rank;
-                epilogue(target_device * row_tiles_per_device + local_cta_row,
+                epilogue(target_device,
+                         local_cta_row,
                          tile_col_idx,
                          &tmem[c * fg::TMEM_PIPELINE_STAGES],
                          c,
@@ -533,9 +549,7 @@ template <int _ROW_BLOCK,
           int SUPERGROUP_WIDTH,
           int _NUM_CONSUMER_WARPS>
 __global__ __cluster_dims__(
-    fused_globals<_ROW_BLOCK, _COL_BLOCK, _NUM_CTA, _NUM_CONSUMER_WARPS>::NUM_CLUSTERS,
-    1,
-    1)
+    fused_globals<_ROW_BLOCK, _COL_BLOCK, _NUM_CTA, _NUM_CONSUMER_WARPS>::NUM_CLUSTERS, 1, 1)
     __launch_bounds__(
         fused_globals<_ROW_BLOCK, _COL_BLOCK, _NUM_CTA, _NUM_CONSUMER_WARPS>::NUM_THREADS,
         1) void fused_kernel_stub(const __grid_constant__ fused_globals<_ROW_BLOCK,


### PR DESCRIPTION
This PR makes 2 main changes to the previous warp specialized AG-GEMM implementation.

1. Improve performance on larger shapes (M=8192, 16384, 32768, N=6288 (KDA))
    - Added a second consumer warp to increase tile size to 512 * 256, from 256 * 256 initially, which trades more B reuse for a shallower load and MMA pipeline
    - Based on autotuning results, this seems to improve performance for KDA shapes with larger Ms by about ~5%, but does not improve performance for MLA shapes
    - For M =  16384, we are at 0.97 of cutlass performance, 1.06 of TK performance
    - For M = 32768, we are at 0.94 of cutlass performance, 1.07 of TK performance
<img width="1189" height="740" alt="AllGather + GEMM (KDA, logical N=6284)_ TFLOP_s by kernel" src="https://github.com/user-attachments/assets/3fbdacc0-fc45-4754-8541-5d2443a508c0" />

2. Simplify the input tensor dimensions
    - previously, I rounded up every row and column dimension to the nearest row / column block granularity. This process of padding and unpadding was simple to do in pytorch and works for the sake of a benchmark
    - to better support integration with raw pointers and to minimize padding and unpadding overhead with raw pointers, we instead use a different tensor indexing scheme:
      -  `A_local_buf`, which is used to store the all-gathered results is now `((NUM_DEVICES, local_m), K)` instead of `(padded_global_m, K)`
      -  `C` is now `((NUM_DEVICES, local_m), n)` rather than `(padded_global_m, n)`
    - TMA will automatically handle the OOB loads / stores, so correctness is still preserved, while minimizing the padding that has to be done 